### PR TITLE
fix compatible WordPress version in readme

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/readme.txt
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/readme.txt
@@ -2,7 +2,7 @@
 Contributors: cloudinary
 Tags: image, images, media, gallery, photo, photos, picture, pictures, thumbnail, upload, admin, administration, api, cms, dashboard, editor, flickr, integration, manage, mobile, page, pages, post, social-media
 Requires at least: 3.0
-Tested up to: 4.0
+Tested up to: 4.6.1
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I tested the plugin on a WordPress 4.6.1 site. It worked perfectly. I'm eager to see the updated plugin but meanwhile the update of the compatible WordPress version in the readme (and on the WP's plugin page) is nice, and increase users' trust in the plugin.
