### PR TITLE
Adds condition for WP_Error, prevents fatal error

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/cloudinary.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/cloudinary.php
@@ -140,6 +140,12 @@ class CloudinaryPlugin
     $fullpathfilename = $uploads['path'] . "/" . $filename;
     
     $response = wp_remote_get($url);
+
+    if( is_wp_error( $response ) ) {
+      $error = $response->get_error_message();      
+      return $public_id . ' cannot be migrate away. ' . $error ;
+    }
+
     if ($response["response"]["code"] != 200) {
       $error = $repsonse["headers"]["x-cld-error"];
       if (!$error) $error = "Unable to migrate away $url";      


### PR DESCRIPTION
If wp_remote_get fails, it will not return a response array but instead an instance of WP_Error. So checking the response as an array results in a fatal error.