### PR TITLE
Fix update_window_dimensions to fire only when library is visible

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
@@ -143,7 +143,7 @@ jQuery(function() {
   if (typeof(tinyMCE) != 'undefined')
     register_edit_image();
   
-  jQuery(document) .on('click', '.cloudinary_add_media', function() {
+  jQuery(document).on('click', '.cloudinary_add_media', function() {
     jQuery('.cloudinary_message').html('');
   	jQuery('#cloudinary-library').show();
   	update_window_dimensions();

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
@@ -77,11 +77,13 @@ jQuery(function() {
   } 
 
   function update_window_dimensions() {  	
-  	var footer = jQuery('#footer').size() > 0 ? jQuery('#footer') : jQuery('#wpfooter');
-  	var body_height = jQuery('body').height() - jQuery(footer).outerHeight(true);
-  	jQuery('#wpcontent').css('margin-left', '156px');
-  	jQuery('#wpbody').css('height', body_height).css('overflow', 'hidden');
-  	jQuery('#cloudinary-library, #cloudinary-library iframe').css('height', body_height);              	
+    if ($('#cloudinary-library').is(':visible')) {
+      var footer = jQuery('#footer').size() > 0 ? jQuery('#footer') : jQuery('#wpfooter');
+      var body_height = jQuery('body').height() - jQuery(footer).outerHeight(true);
+      jQuery('#wpcontent').css('margin-left', '156px');
+      jQuery('#wpbody').css('height', body_height).css('overflow', 'hidden');
+      jQuery('#cloudinary-library, #cloudinary-library iframe').css('height', body_height);
+    }
   }
   
   var controller = {
@@ -141,10 +143,10 @@ jQuery(function() {
   if (typeof(tinyMCE) != 'undefined')
     register_edit_image();
   
-  jQuery('.cloudinary_add_media').click(function() {
+  jQuery(document) .on('click', '.cloudinary_add_media', function() {
     jQuery('.cloudinary_message').html('');
-  	update_window_dimensions();
   	jQuery('#cloudinary-library').show();
+  	update_window_dimensions();
     return false;
   });
   


### PR DESCRIPTION
When a user resizes the window `update_window_dimensions` would lock the height of `#wpbody` regardless of whether the Cloudinary modal is open or not, preventing scrolling and accessing elements below the main content editor. Putting in a check to make sure the modal is open before applying the height and overflow styles.

Also fixing the Cloudinary Upload/Insert button [not working on ACF fields](https://support.cloudinary.com/hc/en-us/community/posts/360022597432-Cloudinary-Upload-Insert-Button-in-Wordpress-Plugin?page=1#community_comment_360002325492)