### PR TITLE
Updating window dimensions on resize breaks page

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/js/cloudinary.js
@@ -109,15 +109,9 @@ jQuery(function() {
           break;
         }        
       },
-      onReady: function() {
-        controller.resizeWatcher();
-      }
     }),
     currentWidth: 0,
     currentHeight: 0,
-    resizeWatcher: function() {      
-      jQuery(window).resize(update_window_dimensions);
-    }
   };  
 
   function register_edit_image() {


### PR DESCRIPTION
Calling the `update_window_dimensions` function on `window.resize` breaks the page, as on line 83 it does `  	jQuery('#wpbody').css('height', body_height).css('overflow', 'hidden');`.  So whenever a user resizes the window, the `#wpbody` will end up with overflow hidden, effectively breaking the page for the user.

There's no need to attach an event listener to the window resize since there's already a click event on the cloudinary button.