### PR TITLE
Change the 'Learn more' link href

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/ui-definitions/tabs/dashboard-content.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/ui-definitions/tabs/dashboard-content.php
@@ -54,7 +54,7 @@ $video_url = ''; // Left blank for when we get the final video URL.
 		<h3><?php esc_html_e( 'More Actions', 'cloudinary' ); ?></h3>
 		<p><span class="dashicons dashicons-image-crop"></span> <?php echo wp_kses_post( $manage_text ); ?></p>
 		<p><span class="dashicons dashicons-welcome-learn-more"></span>
-			<a href="https://cloudinary.com/documentation/cms_ecommerce_integrations#wordpress" target="_blank"> <?php esc_html_e( 'Learn more about getting started' ); ?></a></p>
+			<a href="https://cloudinary.com/documentation/wordpress_integration" target="_blank"> <?php esc_html_e( 'Learn more about getting started' ); ?></a></p>
 	</div>
 </div>
 <?php if ( ! empty( $video_url ) ) : ?>


### PR DESCRIPTION
As requested, this now points to:

https://cloudinary.com/documentation/wordpress_integration

<img width="913" alt="href-changed" src="https://user-images.githubusercontent.com/4063887/73098283-af082680-3eae-11ea-8a26-bc0a73bd54fa.png">
