### PR TITLE
Prevent an error in WP 4.9.12 from field sanitization

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-settings-page.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-settings-page.php
@@ -412,7 +412,18 @@ class Settings_Page implements Component\Assets, Component\Config, Component\Set
 				}
 			} else {
 				if ( is_array( $field ) ) {
-					array_walk_recursive( $field, 'sanitize_text_field' );
+					array_walk_recursive(
+						$field,
+						static function( $field_value ) {
+							// WP 4.9 compatibility, as _sanitize_text_fields() didn't have this check yet, and this prevents an error.
+							// @see https://github.com/WordPress/wordpress-develop/blob/b30baca3ca2feb7f44b3615262ca55fcd87ae232/src/wp-includes/formatting.php#L5307
+							if ( is_object( $field_value ) || is_array( $field_value ) ) {
+								return '';
+							}
+
+							return sanitize_text_field( $field_value );
+						}
+					);
 				} else {
 					$setting[ $slug ] = sanitize_text_field( $field );
 				}


### PR DESCRIPTION
## Steps to reproduce
1. `wp core update --version=4.9.12 --force`
2. Switch to PHP `7.3` if you can
3. Go to /wp-admin/admin.php?page=cld_global_transformation&tab=global_video_transformations
4. Expected: The settings appear
5. Actual: there's a PHP error:
>Recoverable fatal error: Object of class Closure could not be converted to string in /Users/ryankienstra/Projects/sites/sitio/wp-includes/formatting.php on line 1045

![fatal-error-recoverable](https://user-images.githubusercontent.com/4063887/73422999-66a69980-42f0-11ea-9851-0f363f95f71c.png)

## Background
This error is from:

https://github.com/cloudinary/cloudinary_wordpress/blob/9b10a9815b924fb64a6eebd1d8f8db6de2bd35a1/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-settings-page.php#L415

One of the values that is passed to `sanitize_text_field()` is:

![closure-here](https://user-images.githubusercontent.com/4063887/73423180-f77d7500-42f0-11ea-9485-7e6ba5fb7655.png)

`sanitize_text_field` passes that to `_sanitize_text_fields()`. That's not a problem in WP 5.0+, I think. It [now exits](https://github.com/WordPress/wordpress-develop/blob/b30baca3ca2feb7f44b3615262ca55fcd87ae232/src/wp-includes/formatting.php#L5307) for values like closures.

But in WP 4.9, it [didn't yet check](https://github.com/WordPress/wordpress-develop/blame/267c79a5182b3eebdb319874bb5e3ae168a9a6ac/src/wp-includes/formatting.php#L5105) the type, and it caused the error here.

This PR should back-port the WP 5.0 functionality to 4.9. There's no expected change in behavior in WP 5.0+.

But this could use good regression testing on the 'Global Transformations' screens, like at /wp-admin/admin.php?page=cld_global_transformation&tab=global_video_transformations

