### PR TITLE
Prevent assigning error to `$this->usage`

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -279,10 +279,14 @@ class Connect implements Config, Setup, Notice {
 
 			$this->api = new Connect\Api( $this, $this->plugin->version );
 			$stats     = get_transient( '_cloudinary_usage' );
+			if ( is_wp_error( $stats ) ) {
+				return;
+			}
+
 			if ( empty( $stats ) ) {
 				// Get users plan.
 				$stats = $this->plugin->components['connect']->api->usage();
-				if ( ! is_wp_error( $stats ) && ! empty( $stats['media_limits'] ) ) {
+				if ( ! empty( $stats['media_limits'] ) ) {
 					$stats['max_image_size'] = $stats['media_limits']['image_max_size_bytes'];
 					$stats['max_video_size'] = $stats['media_limits']['video_max_size_bytes'];
 					set_transient( '_cloudinary_usage', $stats, HOUR_IN_SECONDS );

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -279,7 +279,6 @@ class Connect implements Config, Setup, Notice {
 
 			$this->api = new Connect\Api( $this, $this->plugin->version );
 			$stats     = get_transient( '_cloudinary_usage' );
-
 			if ( empty( $stats ) ) {
 				// Get users plan.
 				$stats = $this->plugin->components['connect']->api->usage();

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -286,7 +286,7 @@ class Connect implements Config, Setup, Notice {
 			if ( empty( $stats ) ) {
 				// Get users plan.
 				$stats = $this->plugin->components['connect']->api->usage();
-				if ( ! empty( $stats['media_limits'] ) ) {
+				if ( ! is_wp_error( $stats ) && ! empty( $stats['media_limits'] ) ) {
 					$stats['max_image_size'] = $stats['media_limits']['image_max_size_bytes'];
 					$stats['max_video_size'] = $stats['media_limits']['video_max_size_bytes'];
 					set_transient( '_cloudinary_usage', $stats, HOUR_IN_SECONDS );

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -279,14 +279,16 @@ class Connect implements Config, Setup, Notice {
 
 			$this->api = new Connect\Api( $this, $this->plugin->version );
 			$stats     = get_transient( '_cloudinary_usage' );
-			if ( is_wp_error( $stats ) ) {
-				return;
-			}
 
 			if ( empty( $stats ) ) {
 				// Get users plan.
 				$stats = $this->plugin->components['connect']->api->usage();
-				if ( ! is_wp_error( $stats ) && ! empty( $stats['media_limits'] ) ) {
+
+				if ( is_wp_error( $stats ) ) {
+					return;
+				}
+
+				if ( ! empty( $stats['media_limits'] ) ) {
 					$stats['max_image_size'] = $stats['media_limits']['image_max_size_bytes'];
 					$stats['max_video_size'] = $stats['media_limits']['video_max_size_bytes'];
 					set_transient( '_cloudinary_usage', $stats, HOUR_IN_SECONDS );


### PR DESCRIPTION
There was a fatal error reported on activation:
>An error of type E_ERROR was caused in line 340 of the file /path/to/
wp-content/plugins/cloudinary_wordpress_v2/php/sync/class-push-sync.php. Error 
message: Uncaught Error: Cannot use object of type WP_Error as array in 
/path/to/wp-content/plugins/cloudinary_wordpress_v2/php/sync/
class-push-sync.php:340

https://github.com/cloudinary/cloudinary_wordpress/blob/9b10a9815b924fb64a6eebd1d8f8db6de2bd35a1/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php#L340

I couldn't reproduce that, with the same versions as reported in the bug:
PHP 7.4
WP Core 5.3.2
Foodoholic theme

But this PR addresses one possible cause of the error.

It might be possible that `$this->plugin->components['connect']->usage` is a `WP_Error`, causing this fatal error.

It looks like the code anticipates `$stats` being a `WP_Error`:
https://github.com/cloudinary/cloudinary_wordpress/blob/9b10a9815b924fb64a6eebd1d8f8db6de2bd35a1/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php#L285

If so, it will be assigned to `$this->plugin->components['connect']->usage`:

https://github.com/cloudinary/cloudinary_wordpress/blob/9b10a9815b924fb64a6eebd1d8f8db6de2bd35a1/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php#L291

...possibly causing the error the user reported.

Still, I can't reproduce the error that was reported. So it's only a guess that this might fix it.
