### PR TITLE
Cloudinary video player does not conform to transformation string set in the settings

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -391,17 +391,6 @@ window.addEventListener( 'load', function() {
 	}
 
 	/**
-	 * Wraps a JS string in a window.onload callback.
-	 *
-	 * @param string $code
-	 * 
-	 * @return string
-	 */
-	protected function window_onload_wrapper( $code ) {
-		return $code ? "\nwindow.addEventListener( 'load', function () { {$code} });" : '';
-	}
-
-	/**
 	 * Enqueue BLock Assets
 	 */
 	public function enqueue_block_assets() {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -344,7 +344,7 @@ class Video {
 				}
 
 				$code[] = sprintf(
-					'var video_%1$s = cld.videoPlayer( "cloudinary-video-%1$s", %2$s );',
+					'var video%1$s = cld.videoPlayer( "cloudinary-video-%1$s", %2$s );',
 					$instance,
 					wp_json_encode( $config )
 				);
@@ -352,10 +352,13 @@ class Video {
 				if ( isset( $this->config['video_freeform'] ) ) {
 					$code[] = sprintf(
 						'window.onload = function () {
-							var videoContainer = document.getElementById( video_%s.videojs.id_ );
-							videoContainer.style.overflow = "hidden";
-							var videoElement = videoContainer.getElementsByTagName( "video" )[0];
-							videoElement.src = videoElement.src.replace( "upload/", "upload/%s/" );
+							var videoContainer%1$s = document.getElementById( video%s.videojs.id_ );
+							var videoElement%1$s = videoContainer%1$s.getElementsByTagName( "video" )[0];
+							videoElement%1$s.src = videoElement%1$s.src.replace( "upload/", "upload/%2$s/" );
+
+							if ( videoElement%1$s.width < 320 ) {
+								video%1$s.controls(false);
+							}
 						};', 
 						$instance, 
 						$this->config['video_freeform']

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -353,7 +353,7 @@ class Video {
 
 			ob_start();
 			?>
-var cldVideos = <?php echo wp_json_encode( $cld_videos ); ?>;
+			var cldVideos = <?php echo wp_json_encode( $cld_videos ); ?>;
 
 for ( var videoInstance in cldVideos ) {
 	var config = cldVideos[ videoInstance ];

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -378,8 +378,9 @@ window.addEventListener( 'load', function() {
 		}
 	}
 } );
-<?php endif ?>
-			<?php
+			<?php 
+			endif; 
+			
 			$script = ob_get_clean();
 
 			wp_add_inline_script(

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -356,24 +356,23 @@ class Video {
 			var cldVideos = <?php echo wp_json_encode( $cld_videos ); ?>;
 
 for ( var videoInstance in cldVideos ) {
-	var config = cldVideos[ videoInstance ];
-	var id = 'cloudinary-video-' + videoInstance;
-	cld.videoPlayer( id, config );
+	var cldConfig = cldVideos[ videoInstance ];
+	var cldId = 'cloudinary-video-' + videoInstance;
+	cld.videoPlayer( cldId, cldConfig );
 }
 
 <?php if ( $this->config['video_freeform'] ): ?>
 window.addEventListener( 'load', function() {
-	for ( const instance in cldVideos ) {
-		var config = cldVideos[ instance ];
-		var id = 'cloudinary-video-' + instance;
-		var videoContainer = document.getElementById( id );
+	for ( var videoInstance in cldVideos ) {
+		var cldId = 'cloudinary-video-' + videoInstance;
+		var videoContainer = document.getElementById( cldId );
 		var videoElement = videoContainer.getElementsByTagName( 'video' );
 
 		if ( videoElement.length === 1 ) {
 			videoElement = videoElement[0];
 			videoElement.src = videoElement.src.replace( 
 				'upload/', 
-				'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>' 
+				'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/' 
 			);
 		}
 	}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -355,28 +355,28 @@ class Video {
 			?>
 			var cldVideos = <?php echo wp_json_encode( $cld_videos ); ?>;
 
-for ( var videoInstance in cldVideos ) {
-	var cldConfig = cldVideos[ videoInstance ];
-	var cldId = 'cloudinary-video-' + videoInstance;
-	cld.videoPlayer( cldId, cldConfig );
-}
+			for ( var videoInstance in cldVideos ) {
+				var cldConfig = cldVideos[ videoInstance ];
+				var cldId = 'cloudinary-video-' + videoInstance;
+				cld.videoPlayer( cldId, cldConfig );
+			}
 
-<?php if ( $this->config['video_freeform'] ): ?>
-window.addEventListener( 'load', function() {
-	for ( var videoInstance in cldVideos ) {
-		var cldId = 'cloudinary-video-' + videoInstance;
-		var videoContainer = document.getElementById( cldId );
-		var videoElement = videoContainer.getElementsByTagName( 'video' );
+			<?php if ( $this->config['video_freeform'] ): ?>
+			window.addEventListener( 'load', function() {
+				for ( var videoInstance in cldVideos ) {
+					var cldId = 'cloudinary-video-' + videoInstance;
+					var videoContainer = document.getElementById( cldId );
+					var videoElement = videoContainer.getElementsByTagName( 'video' );
 
-		if ( videoElement.length === 1 ) {
-			videoElement = videoElement[0];
-			videoElement.src = videoElement.src.replace( 
-				'upload/', 
-				'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/' 
-			);
-		}
-	}
-} );
+					if ( videoElement.length === 1 ) {
+						videoElement = videoElement[0];
+						videoElement.src = videoElement.src.replace( 
+							'upload/', 
+							'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/' 
+						);
+					}
+				}
+			} );
 			<?php 
 			endif; 
 			

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -344,20 +344,29 @@ class Video {
 				}
 
 				$code[] = sprintf(
-					'var video%1$s = cld.videoPlayer( "cloudinary-video-%1$s", %2$s );',
+					"var video%1\$s = cld.videoPlayer( \"cloudinary-video-%1\$s\", %2\$s );\n",
 					$instance,
 					wp_json_encode( $config )
 				);
 
+				// Apply transformations via URL
+				// The "320" is hardcoded here as that the rough 
+				// estimate of pixels that occupy the player controls.
 				if ( isset( $this->config['video_freeform'] ) ) {
 					$onload_code[] = sprintf(
-						'var videoContainer%1$s = document.getElementById( video%s.videojs.id_ );
-						var videoElement%1$s = videoContainer%1$s.getElementsByTagName( "video" )[0];
-						videoElement%1$s.src = videoElement%1$s.src.replace( "upload/", "upload/%2$s/" );
+						'
+	var videoContainer%1$s = document.getElementById( video%s.videojs.id_ );
+	var videoElement%1$s = videoContainer%1$s.getElementsByTagName( "video" );
 
-						if ( videoElement%1$s.width < 320 ) {
-							video%1$s.controls(false);
-						}', 
+	if ( videoElement%1$s.length === 1 ) {
+		videoElement%1$s = videoElement%1$s[0];
+		videoElement%1$s.src = videoElement%1$s.src.replace( "upload/", "upload/%2$s/" );
+
+		if ( videoElement%1$s.width < 320 ) {
+			video%1$s.controls(false);
+		}
+	}
+', 
 						$instance, 
 						$this->config['video_freeform']
 					);
@@ -382,7 +391,7 @@ class Video {
 	 * @return string
 	 */
 	protected function window_onload_wrapper( $code ) {
-		return $code ? 'window.onload = function () { ' . $code . ' }' : '';
+		return $code ? "\nwindow.onload = function () { {$code} }" : '';
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -338,11 +338,28 @@ class Video {
 				}
 
 				$config = wp_parse_args( $video['args'], $default );
-				// Sizing.
-				if ( empty( $config['size'] ) ) {
+
+				if ( empty( $config['size'] ) && ! isset( $this->config['video_freeform'] ) ) {
 					$config['fluid'] = true;
 				}
-				$code[] = 'cld.videoPlayer(\'cloudinary-video-' . $instance . '\', ' . wp_json_encode( $config ) . ');';
+
+				$code[] = sprintf(
+					'var video_%1$s = cld.videoPlayer("cloudinary-video-%1$s", %2$s);',
+					$instance,
+					wp_json_encode( $config )
+				);
+
+				if ( isset( $this->config['video_freeform'] ) ) {
+					$code[] = sprintf(
+						'window.onload = function () {
+							var videoContainer = document.getElementById(video_%s.videojs.id_);
+							var videoElement = videoContainer.getElementsByTagName("video")[0];
+							videoElement.src = videoElement.src.replace("upload/", "upload/%s/");
+						};', 
+						$instance, 
+						$this->config['video_freeform']
+					);
+				}
 			}
 			// If code was populated, output.
 			if ( ! empty( $code ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -344,7 +344,7 @@ class Video {
 				}
 
 				$code[] = sprintf(
-					"var video%1\$s = cld.videoPlayer( \"cloudinary-video-%1\$s\", %2\$s );\n",
+					'var video%1$s = cld.videoPlayer( "cloudinary-video-%1$s", %2$s );' . "\n",
 					$instance,
 					wp_json_encode( $config )
 				);
@@ -355,7 +355,7 @@ class Video {
 				if ( isset( $this->config['video_freeform'] ) ) {
 					$onload_code[] = sprintf(
 						'
-	var videoContainer%1$s = document.getElementById( video%s.videojs.id_ );
+	var videoContainer%1$s = document.getElementById( video%1$s.videojs.id_ );
 	var videoElement%1$s = videoContainer%1$s.getElementsByTagName( "video" );
 
 	if ( videoElement%1$s.length === 1 ) {
@@ -367,8 +367,8 @@ class Video {
 		}
 	}
 ', 
-						$instance, 
-						$this->config['video_freeform']
+						esc_attr( $instance ), 
+						esc_attr( $this->config['video_freeform'] )
 					);
 				}
 			}
@@ -391,7 +391,7 @@ class Video {
 	 * @return string
 	 */
 	protected function window_onload_wrapper( $code ) {
-		return $code ? "\nwindow.onload = function () { {$code} }" : '';
+		return $code ? "\nwindow.addEventListener( 'load', function () { {$code} });" : '';
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -344,7 +344,7 @@ class Video {
 				}
 
 				$code[] = sprintf(
-					'var video_%1$s = cld.videoPlayer("cloudinary-video-%1$s", %2$s);',
+					'var video_%1$s = cld.videoPlayer( "cloudinary-video-%1$s", %2$s );',
 					$instance,
 					wp_json_encode( $config )
 				);
@@ -352,9 +352,10 @@ class Video {
 				if ( isset( $this->config['video_freeform'] ) ) {
 					$code[] = sprintf(
 						'window.onload = function () {
-							var videoContainer = document.getElementById(video_%s.videojs.id_);
-							var videoElement = videoContainer.getElementsByTagName("video")[0];
-							videoElement.src = videoElement.src.replace("upload/", "upload/%s/");
+							var videoContainer = document.getElementById( video_%s.videojs.id_ );
+							videoContainer.style.overflow = "hidden";
+							var videoElement = videoContainer.getElementsByTagName( "video" )[0];
+							videoElement.src = videoElement.src.replace( "upload/", "upload/%s/" );
 						};', 
 						$instance, 
 						$this->config['video_freeform']


### PR DESCRIPTION
After a lot of research on this bug and a lot of failed attempts, I'm finally happy with my solution. 

As Ryan has described, steps to reproduce:

- In /wp-admin > Cloudinary > Global Transformations > Video Settings, select ‘Cloudinary Player'
- Enter h100,w100 as the ‘Video Transformation String’
- Click ‘Save Settings’
- Create a new post in the block editor
- Add a video block
- Click ‘Media Library’
- Select a video that has been synced with Cloudinary, or upload a video and ensure it’s synced
- Click ‘Select'
- Click ‘Preview’ to see the front-end
- Expected: because there’s a global transformation of h100,w100, the video should be 100 x 100
- Actual: the video is its normal size

The Cloudinary video player JS library has a ton of options that can be added when instantiating it (including `width` and `height`), but simply parsing `w_100` and `h_100` into an options object and passing it didn't seem like a very scalable solution as there are a lot more transformations that could be applied.

I realized that transformations could be directly added to the URL in their short form (ie. w_100), so parsing the transformations is no longer needed.

Example:
> http://res.cloudinary.com/myuser/video/upload/vid.mp4

Turns into:
> http://res.cloudinary.com/myuser/video/upload/w_100,h_100/vid.mp4

I generate a small amount of JS to switch the URL for each Cloudinary video on the page and apply the global transformations accordingly.

Result:

<img width="719" alt="Screen Shot 2020-02-06 at 21 09 27" src="https://user-images.githubusercontent.com/2448254/73974635-01245f80-4925-11ea-8ce4-ad9df7225f13.png">
