### PR TITLE
Fixes bug that causes Cloudinary videos to appear cut

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -361,7 +361,6 @@ class Video {
 				cld.videoPlayer( cldId, cldConfig );
 			}
 
-			<?php if ( $this->config['video_freeform'] ): ?>
 			window.addEventListener( 'load', function() {
 				for ( var videoInstance in cldVideos ) {
 					var cldId = 'cloudinary-video-' + videoInstance;
@@ -370,16 +369,18 @@ class Video {
 
 					if ( videoElement.length === 1 ) {
 						videoElement = videoElement[0];
+						videoElement.style.width = '100%';
+
+						<?php if ( $this->config['video_freeform'] ): ?>
 						videoElement.src = videoElement.src.replace( 
 							'upload/', 
 							'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/' 
 						);
+						<?php endif ?>
 					}
 				}
 			} );
-			<?php 
-			endif; 
-			
+			<?php 			
 			$script = ob_get_clean();
 
 			wp_add_inline_script(


### PR DESCRIPTION
This screenshot demonstrates the bug best:

<img width="811" alt="Screen Shot 2020-02-11 at 15 38 56" src="https://user-images.githubusercontent.com/2448254/74246352-abfd9a80-4ce4-11ea-9c00-4519560155e0.png">

After bug fix:

<img width="812" alt="Screen Shot 2020-02-11 at 15 39 35" src="https://user-images.githubusercontent.com/2448254/74246388-b9b32000-4ce4-11ea-973a-d74d36fcd2bc.png">

There was a hardcoded 300px width being set on the `<video>` element. I override that width on runtime and replace it with 100% instead.