### PR TITLE
Fix a if condition that could stop a listing page

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-delete-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-delete-sync.php
@@ -65,7 +65,8 @@ class Delete_Sync {
 					$has_error = $this->plugin->components['media']->get_post_meta( $post_id, Sync::META_KEYS['sync_error'], true );
 					if ( empty( $has_error ) ) {
 						$all_caps['delete_posts'] = false;
-						if ( filter_input( INPUT_GET, 'action', FILTER_DEFAULT ) ) {
+						$action = filter_input( INPUT_GET, 'action', FILTER_SANITIZE_STRING );
+						if ( ! empty( $action ) && '-1' !== $action ) {
 							wp_die( esc_html__( 'Sorry, you can’t delete an asset until it has fully synced with Cloudinary. Try again once syncing is complete.', 'cloudinary' ) );
 						}
 					}


### PR DESCRIPTION
This PR fixes the described issue on CLOUD 409 and it can be replicated by firing both Bulk Sync media and Auto-Sync or manual push to Cloudinary.
Please refer to the ticket to get more details.