### PR TITLE
fixed regex according to API Environment var

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -157,7 +157,7 @@ class Connect implements Config, Setup, Notice {
 		}
 
 		// Pattern match to ensure validity of the provided url
-		if ( ! preg_match( '~^(?:CLOUDINARY_URL=)?cloudinary://[0-9]+:[A-Za-z_0-9-]+@[\da-f]+~', $data['cloudinary_url'] ) ) {
+		if ( ! preg_match( '~^(?:CLOUDINARY_URL=)?cloudinary://[0-9]+:[A-Za-z_0-9-]+@[A-Za-z0-9-]+~', $data['cloudinary_url'] ) ) {
 			add_settings_error(
 				'cloudinary_connect',
 				'format_mismatch',

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-connect.php
@@ -157,7 +157,7 @@ class Connect implements Config, Setup, Notice {
 		}
 
 		// Pattern match to ensure validity of the provided url
-		if ( ! preg_match( '~^(?:CLOUDINARY_URL=)?cloudinary://[0-9]+:[A-Za-z_0-9]+@[A-Za-z]+~', $data['cloudinary_url'] ) ) {
+		if ( ! preg_match( '~^(?:CLOUDINARY_URL=)?cloudinary://[0-9]+:[A-Za-z_0-9-]+@[\da-f]+~', $data['cloudinary_url'] ) ) {
 			add_settings_error(
 				'cloudinary_connect',
 				'format_mismatch',


### PR DESCRIPTION
Regex for checking API Environment variable is not allowing dashes in the API Secret part.
Furthermore, the cloud name could not contain numbers. As the cloud name seems to be a hex value, the regex has been modified to check for hex