### PR TITLE
Add overwrite_transformations check for global transformations

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php
@@ -228,6 +228,7 @@ class Video {
 		if ( ! empty( $transformations ) ) {
 			$args['transformation'] = $transformations;
 		}
+		$args['overwrite_transformations'] = $overwrite_transformations;
 		// Size settings.
 		$size = '';
 		if ( ! empty( $attr['width'] ) ) {
@@ -307,6 +308,8 @@ class Video {
 			if ( false !== strpos( $classes, 'cld-overwrite' ) ) {
 				$overwrite_transformations = true;
 			}
+			$args['overwrite_transformations'] = $overwrite_transformations;
+
 			$cloudinary_url  = $this->media->cloudinary_url( $attachment_id, false, false, null, $overwrite_transformations );
 			$transformations = $this->media->get_transformations_from_string( $cloudinary_url, 'video' );
 			if ( ! empty( $transformations ) ) {
@@ -384,15 +387,19 @@ class Video {
 					if ( videoElement.length === 1 ) {
 						videoElement = videoElement[0];
 						videoElement.style.width = '100%';
-
 						<?php if ( $this->config['video_freeform'] ): ?>
-							if ( videoElement.src.indexOf( '<?php echo esc_js( $this->config['video_freeform'] ) ?>' ) === -1 ) {
-								videoElement.src = videoElement.src.replace(
-									'upload/',
-									'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/'
-								);
-							}
+
+						if ( 
+							videoElement.src.indexOf( '<?php echo esc_js( $this->config['video_freeform'] ) ?>' ) === -1 &&
+							! cldVideos[videoInstance]['overwrite_transformations']
+						) {
+							videoElement.src = videoElement.src.replace(
+								'upload/',
+								'upload/<?php echo esc_js( $this->config['video_freeform'] ) ?>/'
+							);
+						}
 						<?php endif ?>
+
 					}
 				}
 			} );


### PR DESCRIPTION
Fixes bug where toggling overwrite transformations for a video didn't really affect the outcome on the page and global transformations were being applied regardless.

Steps to test:
* Add some video global transformations
* Enable "overwrite transformations" on a video in a post
* Observe the post - With this fix, the transformations should not be applied.