### PR TITLE
Feature/public id sync

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -100,7 +100,7 @@ class Sync implements Setup, Assets {
 	 */
 	public function is_synced( $post_id ) {
 		$return    = false;
-		$signature = $this->plugin->components['media']->get_post_meta( $post_id, self::META_KEYS['signature'], true );
+		$signature = $this->get_signature( $post_id );
 		if ( ! empty( $signature ) && $this->generate_signature( $post_id ) === $signature ) {
 			$return = $signature;
 		}
@@ -129,6 +129,24 @@ class Sync implements Setup, Assets {
 			},
 			$upload
 		);
+
+		return $return;
+	}
+
+	/**
+	 * Get the current sync signature of an asset.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return array|bool
+	 */
+	public function get_signature( $post_id ) {
+		$return    = false;
+		$signature = $this->plugin->components['media']->get_post_meta( $post_id, self::META_KEYS['signature'], true );
+		if ( ! empty( $signature ) ) {
+			$base_signatures = $this->generate_signature( $post_id );
+			$return          = wp_parse_args( $signature, $base_signatures );
+		}
 
 		return $return;
 	}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -48,6 +48,7 @@ class Sync implements Setup, Assets {
 		'transformation' => '_transformations',
 		'sync_error'     => '_sync_error',
 		'cloudinary'     => '_cloudinary_v2',
+		'folder_sync'    => '_folder_sync',
 	);
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -101,7 +101,8 @@ class Sync implements Setup, Assets {
 	public function is_synced( $post_id ) {
 		$return    = false;
 		$signature = $this->get_signature( $post_id );
-		if ( ! empty( $signature ) && $this->generate_signature( $post_id ) === $signature ) {
+		$expecting = $this->generate_signature( $post_id );
+		if ( ! empty( $signature ) && $expecting === $signature ) {
 			$return = $signature;
 		}
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -141,11 +141,18 @@ class Sync implements Setup, Assets {
 	 * @return array|bool
 	 */
 	public function get_signature( $post_id ) {
-		$return    = false;
-		$signature = $this->plugin->components['media']->get_post_meta( $post_id, self::META_KEYS['signature'], true );
-		if ( ! empty( $signature ) ) {
-			$base_signatures = $this->generate_signature( $post_id );
-			$return          = wp_parse_args( $signature, $base_signatures );
+		static $signatures = array(); // Cache signatures already fetched.
+
+		$return = false;
+		if ( ! empty( $signatures[ $post_id ] ) ) {
+			$return = $signatures[ $post_id ];
+		} else {
+			$signature = $this->plugin->components['media']->get_post_meta( $post_id, self::META_KEYS['signature'], true );
+			if ( ! empty( $signature ) ) {
+				$base_signatures        = $this->generate_signature( $post_id );
+				$signatures[ $post_id ] = wp_parse_args( $signature, $base_signatures );
+				$return                 = $signatures[ $post_id ];
+			}
 		}
 
 		return $return;

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
@@ -62,6 +62,24 @@ class Upgrade {
 				// Has public ID, but not  fully down synced.
 				$cloudinary_id = $public_id;
 			}
+		} else {
+			// Backwards compat.
+			$folder_sync = $this->media->get_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], true );
+			if ( 0 === strlen( $folder_sync ) ) {
+				// Does not exist, add it to be compatible with v1.2.2.
+				$public_id = $this->media->get_post_meta( $attachment_id, Sync::META_KEYS['public_id'], true );
+				// Set the folder sync to 0 to flag it by default as not synced.
+				$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], '0' );
+				if ( false !== strpos( $public_id, '/' ) ) {
+					$path              = pathinfo( $public_id );
+					$asset_folder      = trailingslashit( $path['dirname'] );
+					$cloudinary_folder = trailingslashit( $this->media->plugin->config['settings']['sync_media']['cloudinary_folder'] );
+					if ( $asset_folder === $cloudinary_folder ) {
+						// The asset folder matches the defined cloudinary folder, flag it as being in a folder sync.
+						$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], '1' );
+					}
+				}
+			}
 		}
 
 		return $cloudinary_id;

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
@@ -46,7 +46,10 @@ class Upgrade {
 	public function check_cloudinary_version( $cloudinary_id, $attachment_id ) {
 		if ( false === $cloudinary_id ) {
 			// Backwards compat.
-			$meta      = wp_get_attachment_metadata( $attachment_id );
+			$meta = wp_get_attachment_metadata( $attachment_id );
+			if ( ! empty( $meta[ Sync::META_KEYS['cloudinary'] ] ) ) {
+				return $cloudinary_id; // Current version.
+			}
 			$public_id = $this->media->get_post_meta( $attachment_id, Sync::META_KEYS['public_id'], true );
 
 			/*

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-download-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-download-sync.php
@@ -157,6 +157,16 @@ class Download_Sync {
 		$public_id = strstr( $public_id, '.' . $path['extension'], true );
 		// Save public ID.
 		$media->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
+		// Check if the asset is in the same folder as the defined Cloudinary folder.
+		if ( false !== strpos( $public_id, '/' ) ) {
+			$path              = pathinfo( $public_id );
+			$asset_folder      = trailingslashit( $path['dirname'] );
+			$cloudinary_folder = trailingslashit( $this->plugin->config['settings']['sync_media']['cloudinary_folder'] );
+			if ( $asset_folder === $cloudinary_folder ) {
+				// The asset folder matches the defined cloudinary folder, flag it as being in a folder sync.
+				$media->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], true );
+			}
+		}
 
 		return $this->download_asset( $attachment_id, $file, basename( $file ), $media->get_transformations_from_string( $file ) );
 	}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -304,7 +304,7 @@ class Push_Sync {
 
 		$type = 'upload';
 		// Check for explicit (has public_id, but no breakpoints).
-		$attachment_signature = $this->plugin->components['sync']->generate_signature( $attachment->ID );
+		$attachment_signature = $this->plugin->components['sync']->get_signature( $attachment->ID );
 		if ( empty( $attachment_signature ) ) {
 			if ( ! empty( $attachment->{Sync::META_KEYS['public_id']} ) ) {
 				// Has a public id but no signature, explicit update to complete download.
@@ -312,10 +312,8 @@ class Push_Sync {
 			}
 			// fallback to upload.
 		} else {
-			// Has signature find differences.
+			// Has signature find differences and use specific sync method.
 			$required_signature = $this->plugin->components['sync']->generate_signature( $attachment->ID );
-			// Apply the generated asset signature as a default. To allow for signature extensions that may not exist.
-			$attachment_signature = wp_parse_args( $attachment_signature, $required_signature );
 			foreach ( $required_signature as $key => $signature ) {
 				if ( ( ! isset( $attachment_signature[ $key ] ) || $attachment_signature[ $key ] !== $signature ) && isset( $this->sync_types[ $key ] ) ) {
 					return $this->sync_types[ $key ];

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -429,13 +429,13 @@ class Push_Sync {
 				}
 				$max_width = $this->plugin->components['media']->get_max_width();
 				// Add breakpoints request options.
-				if ( ! empty( $this->plugin->config['settings']['global_transformations']['enable_breakpoints'] ) ) {
+				if ( ! empty( $settings['global_transformations']['enable_breakpoints'] ) ) {
 					$options['responsive_breakpoints'] = array(
 						'create_derived' => true,
-						'bytes_step'     => $this->plugin->config['settings']['global_transformations']['bytes_step'],
-						'max_images'     => $this->plugin->config['settings']['global_transformations']['breakpoints'],
+						'bytes_step'     => $settings['global_transformations']['bytes_step'],
+						'max_images'     => $settings['global_transformations']['breakpoints'],
 						'max_width'      => $meta['width'] < $max_width ? $meta['width'] : $max_width,
-						'min_width'      => $this->plugin->config['settings']['global_transformations']['min_width'],
+						'min_width'      => $settings['global_transformations']['min_width'],
 					);
 					$transformations                   = $this->plugin->components['media']->get_transformation_from_meta( $post->ID );
 					if ( ! empty( $transformations ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -304,7 +304,7 @@ class Push_Sync {
 
 		$type = 'upload';
 		// Check for explicit (has public_id, but no breakpoints).
-		$attachment_signature = $this->plugin->components['media']->get_post_meta( $attachment->ID, Sync::META_KEYS['signature'] );
+		$attachment_signature = $this->plugin->components['sync']->generate_signature( $attachment->ID );
 		if ( empty( $attachment_signature ) ) {
 			if ( ! empty( $attachment->{Sync::META_KEYS['public_id']} ) ) {
 				// Has a public id but no signature, explicit update to complete download.
@@ -400,7 +400,7 @@ class Push_Sync {
 				$public_id = $file_info['filename'];
 			} else {
 				$public_id_parts = pathinfo( $public_id );
-				$public_id = $public_id_parts['basename'];
+				$public_id       = $public_id_parts['basename'];
 			}
 
 			// Prepare upload options.
@@ -470,8 +470,8 @@ class Push_Sync {
 			}
 
 			// Stage folder to public_id.
-			$public_id = $cld_folder . $options['public_id'];
-			$return = array(
+			$public_id                      = $cld_folder . $options['public_id'];
+			$return                         = array(
 				'file'        => $file,
 				'folder'      => $cld_folder,
 				'public_id'   => $public_id,
@@ -480,7 +480,7 @@ class Push_Sync {
 			);
 			$return['options']['public_id'] = $public_id;
 			if ( ! empty( $breakpoints ) ) {
-				$return['breakpoints'] = $breakpoints;
+				$return['breakpoints']              = $breakpoints;
 				$return['breakpoints']['public_id'] = $public_id; // Stage public ID to folder for breakpoints.
 			}
 			$this->upload_options[ $post->ID ] = $return;

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -312,8 +312,10 @@ class Push_Sync {
 			}
 			// fallback to upload.
 		} else {
-			// Has signature. Compare and find if different.
+			// Has signature find differences.
 			$required_signature = $this->plugin->components['sync']->generate_signature( $attachment->ID );
+			// Apply the generated asset signature as a default. To allow for signature extensions that may not exist.
+			$attachment_signature = wp_parse_args( $attachment_signature, $required_signature );
 			foreach ( $required_signature as $key => $signature ) {
 				if ( ( ! isset( $attachment_signature[ $key ] ) || $attachment_signature[ $key ] !== $signature ) && isset( $this->sync_types[ $key ] ) ) {
 					return $this->sync_types[ $key ];

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -398,15 +398,16 @@ class Push_Sync {
 				$public_id = $cld_folder . $file_info['filename'];
 			}
 
+			// Assume that the public_id is a root item.
+			$public_id_folder = '';
+			$public_id_file   = $public_id;
+
+			// Check if in a lower level.
 			if ( false !== strpos( $public_id, '/' ) ) {
 				// Split the public_id into path and filename to allow filtering just the ID and not giving access to the path.
 				$public_id_info   = pathinfo( $public_id );
 				$public_id_folder = trailingslashit( $public_id_info['dirname'] );
 				$public_id_file   = $public_id_info['filename'];
-			} else {
-				// File is in the root of cloudinary.
-				$public_id_folder = '';
-				$public_id_file   = $public_id;
 			}
 
 			// Prepare upload options.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -58,9 +58,10 @@ class Push_Sync {
 		// Define the sync types and their option keys.
 		$sync_types       = array(
 			'file'        => 'upload',
+			'public_id'   => 'rename',
 			'breakpoints' => 'explicit',
 			'options'     => 'context',
-			'folder'      => 'upload',
+			'folder'      => 'rename',
 			'cloud_name'  => 'upload',
 		);
 		$this->sync_types = apply_filters( 'cloudinary_sync_types', $sync_types );
@@ -570,6 +571,13 @@ class Push_Sync {
 						$args['context'] = $upload['options']['context'];
 					}
 					$result = $this->plugin->components['connect']->api->explicit( $args );
+				} elseif ( 'rename' === $sync_type ) {
+					// Rename an asset.
+					$args   = array(
+						'from_public_id' => $this->plugin->components['media']->get_post_meta( $attachment->ID, Sync::META_KEYS['public_id'] ),
+						'to_public_id'   => $upload['public_id'],
+					);
+					$result = $this->plugin->components['connect']->api->{$upload['options']['resource_type']}( 'rename', 'POST', $args );
 				} else {
 					// dynamic sync type..
 					$result = $this->plugin->components['connect']->api->{$sync_type}( $upload['file'], $upload['options'] );

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -304,7 +304,7 @@ class Push_Sync {
 
 		$type = 'upload';
 		// Check for explicit (has public_id, but no breakpoints).
-		$attachment_signature = $attachment->{Sync::META_KEYS['signature']};
+		$attachment_signature = $this->plugin->components['media']->get_post_meta( $attachment->ID, Sync::META_KEYS['signature'] );
 		if ( empty( $attachment_signature ) ) {
 			if ( ! empty( $attachment->{Sync::META_KEYS['public_id']} ) ) {
 				// Has a public id but no signature, explicit update to complete download.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -57,12 +57,12 @@ class Push_Sync {
 
 		// Define the sync types and their option keys.
 		$sync_types       = array(
+			'cloud_name'  => 'upload',
+			'folder'      => 'upload',
 			'file'        => 'upload',
 			'public_id'   => 'rename',
 			'breakpoints' => 'explicit',
 			'options'     => 'context',
-			'folder'      => 'upload',
-			'cloud_name'  => 'upload',
 		);
 		$this->sync_types = apply_filters( 'cloudinary_sync_types', $sync_types );
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -261,6 +261,7 @@ class Upload_Sync {
 		if ( ! in_array( $attachment_id, $this->to_sync, true ) ) {
 			// Flag image as pending to prevent duplicate upload.
 			update_post_meta( $attachment_id, Sync::META_KEYS['pending'], time() );
+			$this->plugin->components['media']->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], true );
 			$this->to_sync[] = $attachment_id;
 		}
 	}


### PR DESCRIPTION
Allows for being able to alter the public_id for uploading as well as correcting the folder changing sync.

**Testing notes.**

This allows for changing the public ID of assets.
Below is an example of using the filter `cloudinary_upload_options` to use the assets slug as it's `public_id` 
Add the snippet in the `functions.php` in your theme.
go to the media library page. If all assets slug is the same as the ID (it should be), then the cloud should be green.

Edit an asset, and change the slug (you may need to select Screen Options, and enable it).
Update and go back to the media library. The image should now be in the syncing state (orange cloud).
After a moment, it should be green and the public ID should be the same as the slug.


```php
	add_filter( 'cloudinary_upload_options', function ( $options, $attachment_post ) {

		/**
		 * Structure of options as follows:
		 *
		 * $options = array(
		 *    'unique_filename' => false, // Allow for auto filenames. See Cloudinary docs.
		 *    'resource_type'   => $resource_type, // Type can be 'image' or 'video' or custom.
		 *    'public_id'       => $public_id, // Changing this will change the public ID as stored in Cloudinary.
		 *    'context'         => array(
		 *        'caption' => esc_attr( $post->post_title ), // Set the caption data in Cloudinary.
		 *        'alt'     => $post->_wp_attachment_image_alt, // set the alt text of the asset in Cloudinary
		 *    ),
		 * );
		 **/

		// To change the asset public_id.
		$post_name = strtolower( $attachment_post->post_name );
		if ( $post_name !== $options['public_id'] ) {
			$options['public_id'] = $post_name;
		}

		return $options;
	}, 10, 2 );
```




