### PR TITLE
ltrim forward slashes on public ID

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -487,7 +487,7 @@ class Push_Sync {
 			}
 
 			// Restructure the path to the filename to allow correct placement in Cloudinary.
-			$public_id                      = $public_id_folder . $options['public_id'];
+			$public_id                      = ltrim( $public_id_folder . $options['public_id'], '/' );
 			$return                         = array(
 				'file'        => $file,
 				'folder'      => $cld_folder,

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -72,7 +72,7 @@ class Upload_Sync {
 		// Hook for on demand upload push.
 		add_action( 'shutdown', array( $this, 'init_background_upload' ) );
 		// Hook into auto upload sync.
-		add_filter( 'cloudinary_on_demand_sync_enabled', array( $this, 'auto_sync_enabled' ) );
+		add_filter( 'cloudinary_on_demand_sync_enabled', array( $this, 'auto_sync_enabled' ), 10, 2 );
 		// Handle bulk and inline actions.
 		add_filter( 'handle_bulk_actions-upload', array( $this, 'handle_bulk_actions' ), 10, 3 );
 		// Add inline action.
@@ -160,11 +160,17 @@ class Upload_Sync {
 	 * Check if auto-sync is enabled.
 	 *
 	 * @param bool $enabled Flag to determine if autosync is enabled.
+	 * @param int  $post_id The post id currently processing.
 	 *
 	 * @return bool
 	 */
-	public function auto_sync_enabled( $enabled ) {
+	public function auto_sync_enabled( $enabled, $post_id ) {
 		if ( isset( $this->plugin->config['settings']['sync_media']['auto_sync'] ) && 'on' === $this->plugin->config['settings']['sync_media']['auto_sync'] ) {
+			$enabled = true;
+		}
+
+		// Check if it was synced before to allow re-sync for changes.
+		if ( ! empty( $this->plugin->components['sync']->get_signature( $post_id ) ) ) {
 			$enabled = true;
 		}
 
@@ -211,7 +217,7 @@ class Upload_Sync {
 		$attachment_id = intval( $attachment_id );
 		if ( $attachment_id && false === $cloudinary_id ) {
 			// Check that this has not already been prepared for upload.
-			if ( ! $this->is_pending( $attachment_id ) && apply_filters( 'cloudinary_on_demand_sync_enabled', $this->enabled ) ) {
+			if ( ! $this->is_pending( $attachment_id ) && apply_filters( 'cloudinary_on_demand_sync_enabled', $this->enabled, $attachment_id ) ) {
 				$max_size = ( wp_attachment_is_image( $attachment_id ) ? 'max_image_size' : 'max_video_size' );
 				$file     = get_attached_file( $attachment_id );
 				// Get the file size to make sure it can exist in cloudinary.


### PR DESCRIPTION
A public ID cannot start with a forward slash.
If the folder is set to none, it defaults to `/` Previously, this was not an issue since we didn't build the folder/public_id structure dynamically. But now, since it is, a root folder asset will start with `/`. i.e `/public-id-jpg`

This fix simply applies a `ltrim( $public_id, '/' )` when combining the folder and id.

An additional fix is that if `auto-upload` is disabled, assets that go out of sync, (changing the folder, or cloudname, etc...) it will show as unsynced. This is because there is a check to see if auto sync is on before uploading. I've added a check to see if it's off unless it's been synced before. if it has, it enables it for just that asset.