### PR TITLE
Remove unslash when editing in Gutenberg

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -524,7 +524,7 @@ class Filter {
 		$context = $request->get_param( 'context' );
 		if ( 'edit' === $context ) {
 			$data                   = $response->get_data();
-			$content                = wp_unslash( $data['content']['raw'] );
+			$content                = $data['content']['raw'];
 			$data['content']['raw'] = $this->filter_out_local( $content );
 
 			$response->set_data( $data );


### PR DESCRIPTION
I tested this for potential side effects, but I can't see any case where removing slashes is necessary here.

@DavidCramer Could I be missing something here?