### PR TITLE
add upgrade handling

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -685,14 +685,22 @@ class Media implements Setup {
 		}
 
 		/**
-		 * Filter the Cloudinary ID to allow extending it's availability.
+		 * Filter to  validate the Cloudinary ID to allow extending it's availability.
 		 *
 		 * @param string|bool $cloudinary_id The public ID from Cloudinary, or false if not found.
 		 * @param int         $attachment_id The id of the asset.
 		 *
 		 * @return string|bool
 		 */
-		$cloudinary_id = apply_filters( 'cloudinary_id', $cloudinary_id, $attachment_id );
+		$cloudinary_id = apply_filters( 'validate_cloudinary_id', $cloudinary_id, $attachment_id );
+
+		/**
+		 * Action the Cloudinary ID to allow extending it's availability.
+		 *
+		 * @param string|bool $cloudinary_id The public ID from Cloudinary, or false if not found.
+		 * @param int         $attachment_id The id of the asset.
+		 */
+		do_action( 'cloudinary_id', $cloudinary_id, $attachment_id );
 		// Cache ID to prevent multiple lookups.
 		if ( false !== $cloudinary_id ) {
 			$this->cloudinary_ids[ $attachment_id ] = $cloudinary_id;

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
@@ -26,12 +26,22 @@ class Upgrade {
 	private $media;
 
 	/**
+	 * Holds the Sync instance.
+	 *
+	 * @since   0.1
+	 *
+	 * @var     \Cloudinary\Sync Instance of the plugin.
+	 */
+	private $sync;
+
+	/**
 	 * Filter constructor.
 	 *
 	 * @param \Cloudinary\Media $media The plugin.
 	 */
 	public function __construct( \Cloudinary\Media $media ) {
 		$this->media = $media;
+		$this->sync  = $media->plugin->components['sync'];
 		$this->setup_hooks();
 	}
 
@@ -44,6 +54,7 @@ class Upgrade {
 	 * @return string|bool
 	 */
 	public function check_cloudinary_version( $cloudinary_id, $attachment_id ) {
+
 		if ( false === $cloudinary_id ) {
 			// Backwards compat.
 			$meta = wp_get_attachment_metadata( $attachment_id );
@@ -128,7 +139,9 @@ class Upgrade {
 		$path      = pathinfo( $public_id );
 		$public_id = strstr( $public_id, '.' . $path['extension'], true );
 		$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
-
+		if ( !defined( 'DOING_BULK_SYNC' ) ) {
+			$this->sync->managers['upload']->add_to_sync( $attachment_id ); // Auto sync if upgrading outside of bulk sync.
+		}
 		return $public_id;
 	}
 
@@ -136,7 +149,7 @@ class Upgrade {
 	 * Setup hooks for the filters.
 	 */
 	public function setup_hooks() {
-		add_filter( 'cloudinary_id', array( $this, 'check_cloudinary_version' ), 10, 2 ); // Priority 10, to allow prep_on_demand_upload.
+		add_filter( 'validate_cloudinary_id', array( $this, 'check_cloudinary_version' ), 10, 2 ); // Priority 10, to allow prep_on_demand_upload.
 
 		// Add a redirection to the new plugin settings, from the old plugin.
 		if ( is_admin() ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-upgrade.php
@@ -139,9 +139,10 @@ class Upgrade {
 		$path      = pathinfo( $public_id );
 		$public_id = strstr( $public_id, '.' . $path['extension'], true );
 		$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
-		if ( !defined( 'DOING_BULK_SYNC' ) ) {
+		if ( ! defined( 'DOING_BULK_SYNC' ) ) {
 			$this->sync->managers['upload']->add_to_sync( $attachment_id ); // Auto sync if upgrading outside of bulk sync.
 		}
+
 		return $public_id;
 	}
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -357,6 +357,7 @@ class Push_Sync {
 			// First check if this has a file and it can be uploaded.
 			$file      = get_attached_file( $post->ID );
 			$file_size = 0;
+			$downsync  = false;
 			if ( empty( $file ) ) {
 				return new \WP_Error( 'attachment_no_file', __( 'Attachment did not have a file.', 'cloudinary' ) );
 			} elseif ( ! file_exists( $file ) ) {
@@ -373,6 +374,7 @@ class Push_Sync {
 						}
 						$file      = get_attached_file( $post->ID );
 						$file_size = filesize( $file );
+						$downsync  = true;
 					}
 				}
 			} else {
@@ -414,7 +416,7 @@ class Push_Sync {
 			}
 			// Check if this asset is a folder sync.
 			$folder_sync = $media->get_post_meta( $post->ID, Sync::META_KEYS['folder_sync'], true );
-			if ( ! empty( $folder_sync ) ) {
+			if ( ! empty( $folder_sync ) && false === $downsync ) {
 				$public_id_folder = $cld_folder; // Ensure the public ID folder is constant.
 			} else {
 				// Not folder synced, so set the folder to the folder that the asset originally came from.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-push-sync.php
@@ -231,9 +231,9 @@ class Push_Sync {
 	public function resume_queue() {
 		// Check if there is a Cloudinary ID in case this was synced on-demand before being processed by the queue.
 		add_filter( 'cloudinary_on_demand_sync_enabled', '__return_false' ); // Disable the on-demand sync since we want the status.
-		add_filter( 'cloudinary_id', '__return_false' ); // Disable the on-demand sync since we want the status.
+		define( 'DOING_BULK_SYNC', true ); // Define bulk sync in action.
 
-		if ( false === $this->plugin->components['media']->cloudinary_id( $this->post_id ) ) {
+		if ( ! $this->plugin->components['sync']->is_synced( $this->post_id ) ) {
 			$stat = $this->push_attachments( array( $this->post_id ) );
 			if ( ! empty( $stat['processed'] ) ) {
 				$result = 'done';
@@ -490,7 +490,7 @@ class Push_Sync {
 			$public_id                      = ltrim( $public_id_folder . $options['public_id'], '/' );
 			$return                         = array(
 				'file'        => $file,
-				'folder'      => $cld_folder,
+				'folder'      => ltrim( $cld_folder, '/' ),
 				'public_id'   => $public_id,
 				'breakpoints' => array(),
 				'options'     => $options,
@@ -542,7 +542,10 @@ class Push_Sync {
 		// Go over each attachment.
 		foreach ( $attachments as $attachment ) {
 			$attachment = get_post( $attachment );
-			$upload     = $this->prepare_upload( $attachment->ID, true );
+			// Clear upload option cache for this item to allow down sync.
+			$this->upload_options[ $attachment->ID ] = false;
+
+			$upload = $this->prepare_upload( $attachment->ID, true );
 
 			// Filter out any attachments with problematic options.
 			if ( is_wp_error( $upload ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -65,8 +65,8 @@ class Upload_Sync {
 	private function register_hooks() {
 		// Add action to upload.
 		add_action( 'add_attachment', array( $this, 'push_on_upload' ), 10 );
-		// Filter id for on-demand upload sync.
-		add_filter( 'cloudinary_id', array( $this, 'prep_on_demand_upload' ), 9, 2 );
+		// Action Cloudinary id for on-demand upload sync.
+		add_action( 'cloudinary_id', array( $this, 'prep_on_demand_upload' ), 9, 2 );
 		// Show sync status.
 		add_filter( 'cloudinary_media_status', array( $this, 'filter_status' ), 10, 2 );
 		// Hook for on demand upload push.


### PR DESCRIPTION
This is to better handle upgrading from v1 - v2+

@pereirinha - The change in `cloudinary_id` filter came into a requirement here, as this allows us to identify upgrade items and act on them without overly filtering.