### PR TITLE
Convert image and videos to blocks when switching from Classic editor to Block editor

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -639,9 +639,7 @@ class Filter {
 		$results[] = $size = 'large';
 		if ( false !== strpos( $class_list, 'size-' ) ) {
 			preg_match( '/size-([A-Za-z0-9-_]+)/', $class_list, $matches );
-
-			$all_sizes = $this->get_intermediate_image_sizes();
-			$results[1] = $size = isset( $matches[1] ) && in_array( $matches[1], $all_sizes ) ? $matches[1] : $size;
+			$results[1] = $size = isset( $matches[1] ) && $matches[1] ? $matches[1] : $size;
 		}
 
 		// Fetch image alignment
@@ -661,22 +659,6 @@ class Filter {
 		);
 
 		return $results;
-	}
-
-	/**
-	 * Fetch all available image sizes, incl. WP defaults.
-	 *
-	 * @return array
-	 */
-	protected function get_intermediate_image_sizes() {
-		$default_sizes    = array( 'thumbnail', 'medium', 'medium_large', 'large' );
-		$additional_sizes = wp_get_additional_image_sizes();
-	
-		if ( ! empty( $additional_sizes ) ) {
-			$default_sizes = array_merge( $default_sizes, array_keys( $additional_sizes ) );
-		}
-
-		return $default_sizes;
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -640,7 +640,7 @@ class Filter {
 		if ( false !== strpos( $class_list, 'size-' ) ) {
 			preg_match( '/size-([A-Za-z0-9-_]+)/', $class_list, $matches );
 
-			$all_sizes = get_intermediate_image_sizes();
+			$all_sizes = wp_get_additional_image_sizes();
 			$results[1] = $size = isset( $matches[1] ) && in_array( $matches[1], $all_sizes ) ? $matches[1] : $size;
 		}
 
@@ -652,11 +652,11 @@ class Filter {
 		}
 
 		// Prep json for block comment
-		$results[] = json_encode( 
+		$results[] = wp_json_encode( 
 			array(
-				'id' 	   => $id,
-				'sizeSlug' => $size,
-				'align'    => $align,
+				'id'		=> $id,
+				'sizeSlug'	=> $size,
+				'align'		=> $align,
 			)	
 		);
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -551,7 +551,7 @@ class Filter {
 
 		$shortcodes = $attrs = array();
 
-		preg_match_all( '/' . get_shortcode_regex() . '/', $content, $shortcodes );
+		preg_match_all( '/' . get_shortcode_regex( array( 'video' ) ) . '/', $content, $shortcodes );
 
 		for ( $i = 0; $i < count( $shortcodes[3] ); $i++ ) {
 			preg_match_all( '/(mp4|id)="([^"]*)"/i', $shortcodes[3][$i], $attrs );
@@ -559,7 +559,7 @@ class Filter {
 			// @TODO: Find a way to generate a video block
 			$video = '<!-- wp:video {"id":' . $attrs[2][1] . '} --><figure class="wp-block-video"><video autoplay src="' . $attrs[2][0] . '"></video></figure><!-- /wp:video -->';
 	
-			$content = str_replace( [ '<p>' . $shortcodes[0][$i] . '</p>', $shortcodes[0][$i] ], $video, $content );
+			$content = str_replace( array( '<p>' . $shortcodes[0][$i] . '</p>', $shortcodes[0][$i] ), $video, $content );
 		}
 
 		return $content;

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -577,7 +577,10 @@ class Filter {
 			return $content;
 		}
 
-		$dom = new \DOMDocument();                
+		$dom = new \DOMDocument();       
+		
+		// Suppress errors here as we are not supplying a full-fledged
+		// HTML document, which will cause loadHTML to throw errors.
 		@$dom->loadHTML( $content, LIBXML_HTML_NODEFDTD );
 		$imgs = $dom->getElementsByTagName( 'img' );
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -640,7 +640,7 @@ class Filter {
 		if ( false !== strpos( $class_list, 'size-' ) ) {
 			preg_match( '/size-([A-Za-z0-9-_]+)/', $class_list, $matches );
 
-			$all_sizes = wp_get_additional_image_sizes();
+			$all_sizes = $this->get_intermediate_image_sizes();
 			$results[1] = $size = isset( $matches[1] ) && in_array( $matches[1], $all_sizes ) ? $matches[1] : $size;
 		}
 
@@ -661,6 +661,22 @@ class Filter {
 		);
 
 		return $results;
+	}
+
+	/**
+	 * Fetch all available image sizes, incl. WP defaults.
+	 *
+	 * @return array
+	 */
+	protected function get_intermediate_image_sizes() {
+		$default_sizes    = array( 'thumbnail', 'medium', 'medium_large', 'large' );
+		$additional_sizes = wp_get_additional_image_sizes();
+	
+		if ( ! empty( $additional_sizes ) ) {
+			$default_sizes = array_merge( $default_sizes, array_keys( $additional_sizes ) );
+		}
+
+		return $default_sizes;
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -549,15 +549,20 @@ class Filter {
 			return $content;
 		}
 
-		$shortcode = $attrs = array();
+		$shortcodes = $attrs = array();
 
-		preg_match( '/' . get_shortcode_regex() . '/', $content, $shortcode );
-		preg_match_all( '/(mp4|id)="([^"]*)"/i', $shortcode[3], $attrs );
+		preg_match_all( '/' . get_shortcode_regex() . '/', $content, $shortcodes );
 
-		// @TODO: Find a way to generate a video block
-		$video = '<!-- wp:video {"id":' . $attrs[2][1] . '} --><figure class="wp-block-video"><video autoplay src="' . $attrs[2][0] . '"></video></figure><!-- /wp:video -->';
+		for ( $i = 0; $i < count( $shortcodes[3] ); $i++ ) {
+			preg_match_all( '/(mp4|id)="([^"]*)"/i', $shortcodes[3][$i], $attrs );
+	
+			// @TODO: Find a way to generate a video block
+			$video = '<!-- wp:video {"id":' . $attrs[2][1] . '} --><figure class="wp-block-video"><video autoplay src="' . $attrs[2][0] . '"></video></figure><!-- /wp:video -->';
+	
+			$content = str_replace( [ '<p>' . $shortcodes[0][$i] . '</p>', $shortcodes[0][$i] ], $video, $content );
+		}
 
-		return str_replace( [ '<p>' . $shortcode[0] . '</p>', $shortcode[0] ], $video, $content );
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
Test notes:

- Have both Classic and Block editors ready for use
- Create a post using Classic Editor, insert image and/or video
- Save the post
- Switch to Gutenberg
- Image and video content should've been converted to their respective blocks rather than "Classic Block"