### PR TITLE
add check that a synctype is still available

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -610,7 +610,7 @@ class Sync implements Setup, Assets {
 	 */
 	public function filter_status( $status, $attachment_id ) {
 
-		if ( $this->been_synced( $attachment_id ) && $this->is_pending( $attachment_id ) && $this->get_sync_type( $attachment_id ) ) {
+		if ( $this->been_synced( $attachment_id ) || ( $this->is_pending( $attachment_id ) && $this->get_sync_type( $attachment_id ) ) ) {
 			$sync_type = $this->get_sync_type( $attachment_id );
 			if ( ! empty( $sync_type ) && isset( $this->sync_base_struct[ $sync_type ] ) ) {
 				// check process log in case theres an error.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php
@@ -610,7 +610,7 @@ class Sync implements Setup, Assets {
 	 */
 	public function filter_status( $status, $attachment_id ) {
 
-		if ( $this->been_synced( $attachment_id ) || $this->is_pending( $attachment_id ) ) {
+		if ( $this->been_synced( $attachment_id ) && $this->is_pending( $attachment_id ) && $this->get_sync_type( $attachment_id ) ) {
 			$sync_type = $this->get_sync_type( $attachment_id );
 			if ( ! empty( $sync_type ) && isset( $this->sync_base_struct[ $sync_type ] ) ) {
 				// check process log in case theres an error.


### PR DESCRIPTION
@pereirinha - the metadata on whats saved (pending, syncing etc) may be outdated. If there is no sync-type needed due to the signature being in sync and up to date, don't show meta data notices, since it's no longer relevant.