### PR TITLE
Broken links on content created while Cloudinary is single source.

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -630,12 +630,13 @@ class Media implements Setup {
 	 * @return string Cloudinary URL.
 	 */
 	public function attachment_url( $url, $attachment_id ) {
+		// Previous v1 and Cloudinary only storage.
+		$previous_url = strpos( $url, untrailingslashit( $this->base_url ) );
+		if ( false !== $previous_url ) {
+			return substr( $url, $previous_url );
+		}
 		if ( ! doing_action( 'wp_insert_post_data' ) && false === $this->in_downsize ) {
-			// Previous v1.
-			$previous_url = strpos( $url, untrailingslashit( $this->base_url ) );
-			if ( false !== $previous_url ) {
-				$url = substr( $url, $previous_url );
-			} elseif ( $this->cloudinary_id( $attachment_id ) ) {
+			if ( $this->cloudinary_id( $attachment_id ) ) {
 				$url = $this->cloudinary_url( $attachment_id );
 			}
 		}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -243,14 +243,7 @@ class Filter {
 	 * @return array
 	 */
 	public function filter_out_cloudinary( $data ) {
-		/**
-		 * Filter to allow programmatic disabling of Filtering out URLS.
-		 *
-		 * @param bool
-		 */
-		if ( ! apply_filters( 'cloudinary_can_filter_out_cloudinary', true ) ) {
-			return $data;
-		}
+
 		$content = trim( wp_unslash( $data['post_content'] ) );
 		$assets  = $this->get_media_tags( $content );
 
@@ -269,7 +262,10 @@ class Filter {
 			} else {
 				$local_url = wp_get_attachment_url( $attachment_id );
 			}
-
+			// Skip since there is no local available.
+			if ( $this->media->is_cloudinary_url( $local_url ) ) {
+				continue;
+			}
 			$inherit_transformations = $this->media->get_transformation_from_meta( $attachment_id );
 			$transformations         = $this->media->get_transformations_from_string( $url );
 			$transformations         = array_filter( $transformations );
@@ -352,7 +348,7 @@ class Filter {
 			if ( $url === $cloudinary_url ) {
 				continue;
 			}
-			
+
 			// Replace old tag.
 			$new_tag = str_replace( $url, $cloudinary_url, $asset );
 
@@ -363,9 +359,9 @@ class Filter {
 			}
 
 			// Apply lazy loading attribute
-			if ( 
-				apply_filters( 'wp_lazy_loading_enabled', true ) && 
-				false === strpos( $new_tag, 'loading="lazy"' ) && 
+			if (
+				apply_filters( 'wp_lazy_loading_enabled', true ) &&
+				false === strpos( $new_tag, 'loading="lazy"' ) &&
 				$clean
 			) {
 				$new_tag = str_replace( '/>', ' loading="lazy" />', $new_tag );
@@ -390,7 +386,7 @@ class Filter {
 	/**
 	 * Return a Cloudinary URL for an attachment used in JS.
 	 *
-	 * @param array    $attachment The attachment response array.
+	 * @param array $attachment The attachment response array.
 	 *
 	 * @return array
 	 * @uses filter:wp_prepare_attachment_for_js
@@ -433,11 +429,11 @@ class Filter {
 	/**
 	 * Return a Cloudinary URL for an attachment used in a REST REQUEST.
 	 *
-	 * @uses filter:rest_prepare_attachment
-	 *
 	 * @param \WP_REST_Response $attachment The attachment array to be used in JS.
 	 *
 	 * @return \WP_REST_Response
+	 * @uses filter:rest_prepare_attachment
+	 *
 	 */
 	public function filter_attachment_for_rest( $attachment ) {
 		if ( ! isset( $attachment->data['id'] ) ) {
@@ -528,7 +524,7 @@ class Filter {
 			}
 			if ( ! empty( $attachment['transformations'] ) ) {
 				$transformation_string = Api::generate_transformation_string( $attachment['transformations'] );
-				$new_atts             .= ' transformations="' . esc_attr( $transformation_string ) . '"';
+				$new_atts              .= ' transformations="' . esc_attr( $transformation_string ) . '"';
 			}
 			$html = str_replace( $shortcode['args'], $new_atts, $html );
 		}
@@ -706,7 +702,7 @@ class Filter {
 		add_filter( 'the_content', array( $this, 'filter_out_local' ), 9 ); // Early to hook before responsive srcsets.
 		add_filter( 'wp_prepare_attachment_for_js', array( $this, 'filter_attachment_for_js' ), 11 );
 
-    // Add support for custom header.
+		// Add support for custom header.
 		add_filter( 'get_header_image_tag', array( $this, 'filter_out_local' ) );
 
 		// Add transformations.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -524,7 +524,7 @@ class Filter {
 			}
 			if ( ! empty( $attachment['transformations'] ) ) {
 				$transformation_string = Api::generate_transformation_string( $attachment['transformations'] );
-				$new_atts              .= ' transformations="' . esc_attr( $transformation_string ) . '"';
+				$new_atts             .= ' transformations="' . esc_attr( $transformation_string ) . '"';
 			}
 			$html = str_replace( $shortcode['args'], $new_atts, $html );
 		}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-filter.php
@@ -243,7 +243,14 @@ class Filter {
 	 * @return array
 	 */
 	public function filter_out_cloudinary( $data ) {
-
+		/**
+		 * Filter to allow programmatic disabling of Filtering out URLS.
+		 *
+		 * @param bool
+		 */
+		if ( ! apply_filters( 'cloudinary_can_filter_out_cloudinary', true ) ) {
+			return $data;
+		}
 		$content = trim( wp_unslash( $data['post_content'] ) );
 		$assets  = $this->get_media_tags( $content );
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
@@ -196,6 +196,7 @@ class Storage implements Notice {
 		$this->sync->set_signature_item( $attachment_id, 'storage' );
 		$this->sync->set_signature_item( $attachment_id, 'breakpoints' );
 		$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['storage'], $this->settings['offload'] ); // Save the state.
+		$this->sync->managers['upload']->update_content( $attachment_id );
 	}
 
 	/**
@@ -304,6 +305,22 @@ class Storage implements Notice {
 	}
 
 	/**
+	 * Maybe stop filtering out Cloudinary URLs.
+	 * If storage is Cloudinary only, we need to save full Cloudinary URLS, since local's don't exist.
+	 *
+	 * @param bool $filter_out Flag to stop filtering out.
+	 *
+	 * @return bool
+	 */
+	public function save_cloudinary_links_maybe( $filter_out ) {
+		if ( 'cld' === $this->settings['offload'] ) {
+			$filter_out = false;
+		}
+
+		return $filter_out;
+	}
+
+	/**
 	 * Setup hooks for the filters.
 	 */
 	public function setup() {
@@ -332,7 +349,7 @@ class Storage implements Notice {
 			// Tag the deactivate button.
 			$plugin_file = pathinfo( dirname( CLDN_CORE ), PATHINFO_BASENAME ) . '/' . basename( CLDN_CORE );
 			add_filter( 'plugin_action_links_' . $plugin_file, array( $this, 'tag_deactivate_link' ) );
-
+			add_filter( 'cloudinary_can_filter_out_cloudinary', array( $this, 'save_cloudinary_links_maybe' ) );
 
 		}
 	}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
@@ -305,22 +305,6 @@ class Storage implements Notice {
 	}
 
 	/**
-	 * Maybe stop filtering out Cloudinary URLs.
-	 * If storage is Cloudinary only, we need to save full Cloudinary URLS, since local's don't exist.
-	 *
-	 * @param bool $filter_out Flag to stop filtering out.
-	 *
-	 * @return bool
-	 */
-	public function save_cloudinary_links_maybe( $filter_out ) {
-		if ( 'cld' === $this->settings['offload'] ) {
-			$filter_out = false;
-		}
-
-		return $filter_out;
-	}
-
-	/**
 	 * Setup hooks for the filters.
 	 */
 	public function setup() {
@@ -328,7 +312,7 @@ class Storage implements Notice {
 		$this->sync     = $this->plugin->get_component( 'sync' );
 		$this->connect  = $this->plugin->get_component( 'connect' );
 		$this->media    = $this->plugin->get_component( 'media' );
-		$this->download = $this->sync->managers['download'] ? $this->sync->managers['download'] : new Download_Sync( $plugin );
+		$this->download = $this->sync->managers['download'] ? $this->sync->managers['download'] : new Download_Sync( $this->plugin );
 
 		if ( $this->is_ready() ) {
 			$defaults       = array(
@@ -349,8 +333,6 @@ class Storage implements Notice {
 			// Tag the deactivate button.
 			$plugin_file = pathinfo( dirname( CLDN_CORE ), PATHINFO_BASENAME ) . '/' . basename( CLDN_CORE );
 			add_filter( 'plugin_action_links_' . $plugin_file, array( $this, 'tag_deactivate_link' ) );
-			add_filter( 'cloudinary_can_filter_out_cloudinary', array( $this, 'save_cloudinary_links_maybe' ) );
-
 		}
 	}
 }

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-storage.php
@@ -196,7 +196,10 @@ class Storage implements Notice {
 		$this->sync->set_signature_item( $attachment_id, 'storage' );
 		$this->sync->set_signature_item( $attachment_id, 'breakpoints' );
 		$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['storage'], $this->settings['offload'] ); // Save the state.
-		$this->sync->managers['upload']->update_content( $attachment_id );
+		// If bringing media back to WordPress, we need to trigger content update to allow unfiltered Cloudinary URL's to be filtered.
+		if ( ! empty( $previous_state ) && 'cld' !== $this->settings['offload'] ) {
+			$this->sync->managers['upload']->update_content( $attachment_id );
+		}
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -325,7 +325,7 @@ class Upload_Sync {
 	 *
 	 * @param int $attachment_id The attachment id to find and init an update.
 	 */
-	private function update_content( $attachment_id ) {
+	public function update_content( $attachment_id ) {
 		// Search and update link references in content.
 		$content_search = new \WP_Query( array( 's' => 'wp-image-' . $attachment_id, 'fields' => 'ids', 'posts_per_page' => 1000 ) );
 		if ( ! empty( $content_search->found_posts ) ) {


### PR DESCRIPTION
If Cloudinary is the single storage source, images inserted in content will try to have Cloudinary URL's filtered into local URLs for saving.
Since these don't exist anymore, we get a broken link in the DB. This is only noticeable if the plugin is disabled though, since the URL's are filtered out while the plugin is active.

Migrating back to WordPress and Cloudinary, also resolves this as it is then able to locate the files. 