### PR TITLE
Correctly match the the file_location and cloudinary_id

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -1799,20 +1799,11 @@ class Media implements Setup {
 	 */
 	public function match_file_name_with_cloudinary_source( $image_meta, $attachment_id ) {
 		if ( $this->has_public_id( $attachment_id ) ) {
-			$cld_file = $this->get_cloudinary_id( $attachment_id );
+
+			$cld_file = $this->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true ) . '/' . $this->get_cloudinary_id( $attachment_id );
 
 			if ( false === strpos( $image_meta['file'], $cld_file ) ) {
 				$image_meta['file'] = $cld_file;
-
-				// Match sizes to exclude sizes suffix.
-				if ( isset( $image_meta['sizes'] ) ) {
-					// Create backup sizes.
-					$image_meta['backup_sizes'] = $image_meta['sizes'];
-					// Match sizes to exclude sizes suffix.
-					foreach ( $image_meta['sizes'] as &$size ) {
-						$size['file'] = basename( $cld_file );
-					}
-				}
 			}
 		}
 

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -739,7 +739,7 @@ class Media implements Setup {
 		// Setup initial args for cloudinary_url.
 		$pre_args = array(
 			'secure'        => is_ssl(),
-			'version'       => $this->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true ),
+			'version'       => $this->get_cloudinary_version( $attachment_id ),
 			'resource_type' => $resource_type,
 		);
 
@@ -1311,7 +1311,7 @@ class Media implements Setup {
 					update_post_meta( $asset['attachment_id'], '_wp_attachment_image_alt', $alt_text );
 				}
 				// Compare Version.
-				$current_version = (int) $this->get_post_meta( $asset['attachment_id'], Sync::META_KEYS['version'], true );
+				$current_version = $this->get_cloudinary_version( $asset['attachment_id'] );
 				if ( $current_version !== $asset['version'] ) {
 					// Difference version, remove files, and downsync new files related to this asset.
 					// If this is a different version, we should try find attachments with the base sync key and update the source.
@@ -1746,6 +1746,19 @@ class Media implements Setup {
 	}
 
 	/**
+	 * Get the cloudinary version of an attachment.
+	 *
+	 * @param int $attachment_id The attachment_ID.
+	 *
+	 * @return string
+	 */
+	public function get_cloudinary_version( $attachment_id ) {
+		$version = (int) $this->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true );
+
+		return $version ? $version : 1;
+	}
+
+	/**
 	 * Setup the hooks and base_url if configured.
 	 */
 	public function setup() {
@@ -1799,9 +1812,7 @@ class Media implements Setup {
 	 */
 	public function match_file_name_with_cloudinary_source( $image_meta, $attachment_id ) {
 		if ( $this->has_public_id( $attachment_id ) ) {
-
-			$cld_file = $this->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true ) . '/' . $this->get_cloudinary_id( $attachment_id );
-
+			$cld_file = 'v' . $this->get_cloudinary_version( $attachment_id ) . '/' . $this->get_cloudinary_id( $attachment_id );
 			if ( false === strpos( $image_meta['file'], $cld_file ) ) {
 				$image_meta['file'] = $cld_file;
 			}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -1750,7 +1750,7 @@ class Media implements Setup {
 	 *
 	 * @param int $attachment_id The attachment_ID.
 	 *
-	 * @return string
+	 * @return int
 	 */
 	public function get_cloudinary_version( $attachment_id ) {
 		$version = (int) $this->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true );

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -222,7 +222,7 @@ class Upload_Sync {
 			// Check that this wasn't an existing.
 			if ( ! empty( $result['existing'] ) ) {
 				// Check to see if this is the same image.
-				$version = (int) $this->media->get_post_meta( $attachment_id, Sync::META_KEYS['version'], true );
+				$version = $this->media->get_cloudinary_version( $attachment_id );
 				if ( $version !== $result['version'] ) {
 					// New image with the same name.
 					// Add a suffix and try again.


### PR DESCRIPTION

use `Media::cloudinary_id()` method to get file path, name, suffix, and extension.