### PR TITLE
Reset folder

### DIFF
--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -633,7 +633,7 @@ class Media implements Setup {
 		if ( false !== $previous_url ) {
 			return substr( $url, $previous_url );
 		}
-		if ( ! doing_action( 'wp_insert_post_data' ) && false === $this->in_downsize ) {
+		if ( ! doing_action( 'wp_insert_post_data' ) && false === $this->in_downsize && ! apply_filters( 'cloudinary_doing_upload', '__return_false' ) ) {
 			if ( $this->cloudinary_id( $attachment_id ) ) {
 				$url = $this->cloudinary_url( $attachment_id );
 			}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -633,7 +633,19 @@ class Media implements Setup {
 		if ( false !== $previous_url ) {
 			return substr( $url, $previous_url );
 		}
-		if ( ! doing_action( 'wp_insert_post_data' ) && false === $this->in_downsize && ! apply_filters( 'cloudinary_doing_upload', '__return_false' ) ) {
+		if (
+			! doing_action( 'wp_insert_post_data' )
+			&& false === $this->in_downsize
+			/**
+			 * Filter doing upload.
+			 * If so, return the default attachment URL.
+			 *
+			 * @param bool Default false.
+			 *
+			 * @return bool
+			 */
+			&& ! apply_filters( 'cloudinary_doing_upload', false )
+		) {
 			if ( $this->cloudinary_id( $attachment_id ) ) {
 				$url = $this->cloudinary_url( $attachment_id );
 			}

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -1678,12 +1678,22 @@ class Media implements Setup {
 	 */
 	public function is_folder_synced( $attachment_id ) {
 
-		$return = true; // By default all assets in WordPress will be synced.
+		$is_folder_synced = true; // By default all assets in WordPress will be synced.
 		if ( $this->sync->been_synced( $attachment_id ) ) {
-			$return = ! empty( $this->get_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], true ) );
+			$is_folder_synced = ! empty( $this->get_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], true ) );
 		}
 
-		return $return;
+		/**
+		 * Filter is folder synced flag.
+		 *
+		 * @param bool $is_folder_synced Flag value for is folder sync.
+		 * @param int  $attachment_id    The attachment ID.
+		 *
+		 * @return bool
+		 */
+		$is_folder_synced = apply_filters( 'cloudinary_is_folder_synced', $is_folder_synced, $attachment_id );
+
+		return (bool) $is_folder_synced;
 	}
 
 	/**

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -1051,6 +1051,8 @@ class Media implements Setup {
 		$transformations = $this->get_post_meta( $attachment_id, Sync::META_KEYS['transformation'], true );
 		// Use Cloudinary breakpoints for same ratio.
 
+		$image_meta['overwrite_transformations'] = ! empty( $image_meta['overwrite_transformations'] ) ? $image_meta['overwrite_transformations'] : false;
+
 		if ( 'on' === $this->plugin->config['settings']['global_transformations']['enable_breakpoints'] && wp_image_matches_ratio( $image_meta['width'], $image_meta['height'], $size_array[0], $size_array[1] ) ) {
 			$meta = $this->get_post_meta( $attachment_id, Sync::META_KEYS['breakpoints'], true );
 			if ( ! empty( $meta ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-media.php
@@ -762,7 +762,7 @@ class Media implements Setup {
 
 		// Make a copy as not to destroy the options in \Cloudinary::cloudinary_url().
 		$args = $pre_args;
-		$url  = $this->plugin->components['connect']->api->cloudinary_url( $cloudinary_id, $args, $size, $clean );
+		$url  = $this->plugin->components['connect']->api->cloudinary_url( $cloudinary_id, $args, $size );
 
 		// Check if this type is a preview only type. i.e PDF.
 		if ( ! empty( $size ) && $this->is_preview_only( $attachment_id ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/connect/class-api.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/connect/class-api.php
@@ -410,6 +410,7 @@ class Api {
 		$disable_https_fetch = get_transient( '_cld_disable_http_upload' );
 		$file_url            = wp_get_original_image_url( $attachment_id );
 		$media               = get_plugin_instance()->get_component( 'media' );
+		$tempfile            = false;
 		if ( $media && $media->is_cloudinary_url( $file_url ) ) {
 			// If this is a Cloudinary URL, then we can use it to fetch from that location.
 			$disable_https_fetch = false;
@@ -429,7 +430,6 @@ class Api {
 					return $this->upload_large( $attachment_id, $args );
 				}
 			}
-			$tempfile = false;
 			if ( false !== strpos( $args['file'], 'vip://' ) ) {
 				$args['file'] = $this->create_local_copy( $args['file'] );
 				if ( is_wp_error( $args['file'] ) ) {

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -233,7 +233,6 @@ class Upload_Sync {
 				}
 			}
 
-
 			// Set folder Synced.
 			$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], $this->media->is_folder_synced( $attachment_id ) );
 			// Set public_id.

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -201,6 +201,21 @@ class Upload_Sync {
 	 */
 	public function upload_asset( $attachment_id ) {
 
+		add_filter( 'cloudinary_doing_upload', '__return_true' );
+
+		add_filter(
+			'cloudinary_is_folder_synced',
+			function( $is_synced, $post_id ) use ( $attachment_id ) {
+				if ( $post_id === $attachment_id ) {
+					return true;
+				}
+
+				return $is_synced;
+			},
+			10,
+			2
+		);
+
 		$type      = $this->sync->get_sync_type( $attachment_id );
 		$options   = $this->media->get_upload_options( $attachment_id );
 		$public_id = $options['public_id'];

--- a/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
+++ b/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php
@@ -217,6 +217,8 @@ class Upload_Sync {
 		// Run the upload Call.
 		$result = $this->connect->api->upload( $attachment_id, $options );
 
+		remove_filter( 'cloudinary_doing_upload', '__return_true' );
+
 		if ( ! is_wp_error( $result ) ) {
 
 			// Check that this wasn't an existing.


### PR DESCRIPTION
Allows pushing an asset update — either via `Re-sync to Cloudinary` or the bulk action `Push to Cloudinary` — that resets the location of the asset in Cloudinary account to the folder set in WordPress.