### PR TITLE
Wrap the `posts_per_page` paramiter of sync query filterable

### DIFF
--- a/php/sync/class-sync-queue.php
+++ b/php/sync/class-sync-queue.php
@@ -252,7 +252,7 @@ class Sync_Queue {
 			'post_type'           => 'attachment',
 			'post_mime_type'      => array( 'image', 'video' ),
 			'post_status'         => 'inherit',
-			'posts_per_page'      => 1000, // phpcs:ignore
+			'posts_per_page'      => apply_filters( 'cloudinary_sync_limit', 1000 ), // phpcs:ignore
 			'fields'              => 'ids',
 			'meta_query'          => array( // phpcs:ignore
 				'relation' => 'AND',

--- a/ui-definitions/tabs/sync-media-footer.php
+++ b/ui-definitions/tabs/sync-media-footer.php
@@ -24,7 +24,7 @@ if ( ! $this->plugin->components['sync']->managers['queue']->is_running() ) {
 	<?php if ( $this->plugin->config['connect'] ) : ?>
 
 		<p>
-			<?php esc_html_e( "Bulk Sync is a one-time operation that ensures that the Cloudinary Media Library is up-to-date with the WordPress Media Library by manually pushing all media that was stored in your WordPress Media Library prior to activation of the Cloudinary plugin. Please note that there is a limit of 1000 images at a time so your server doesn't get overloaded.", 'cloudinary' ); ?>
+			<?php esc_html_e( "Bulk Sync is a one-time operation that ensures that the Cloudinary Media Library is up-to-date with the WordPress Media Library by manually pushing all media that was stored in your WordPress Media Library prior to activation of the Cloudinary plugin. Please note that there is a default limit of 1000 images at a time so your server doesn't get overloaded.", 'cloudinary' ); ?>
 		</p>
 
 		<button type="button" class="button button-hero stop-sync" id="stop-sync"><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'Stop Sync', 'cloudinary' ); ?></button>


### PR DESCRIPTION
Adds `cloudinary_sync_limit` filter around the value used for the `posts_per_page` part of the sync query so it can be reduced or increased depending on the needs of the site sync is being run on.

Fixes: #281 