### PR TITLE
get get_url defect

### DIFF
--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -663,8 +663,8 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		$this->usage_notices();
 		$screen             = get_current_screen();
 		$connection_setting = $this->settings->find_setting( self::META_KEYS['url'] );
-		$slg                = $connection_setting->get_value();
-		if ( empty( $slg ) ) {
+		$cloudinary_url     = $connection_setting->get_value();
+		if ( empty( $cloudinary_url ) ) {
 			$page_base = $this->settings->get_root_setting()->get_slug();
 			if ( is_object( $screen ) && $page_base === $screen->parent_base ) {
 				$url             = $connection_setting->get_option_parent()->get_component()->get_url();

--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -661,18 +661,13 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 	 */
 	public function get_notices() {
 		$this->usage_notices();
-		$screen = get_current_screen();
-		$slg    = $this->settings->find_setting( 'cloudinary_url' )->get_value();
+		$screen             = get_current_screen();
+		$connection_setting = $this->settings->find_setting( self::META_KEYS['url'] );
+		$slg                = $connection_setting->get_value();
 		if ( empty( $slg ) ) {
 			$page_base = $this->settings->get_root_setting()->get_slug();
 			if ( is_object( $screen ) && $page_base === $screen->parent_base ) {
-				$url             = add_query_arg(
-					array(
-						'page' => 'dashboard',
-						'tab'  => 'connect',
-					),
-					admin_url( 'admin.php' )
-				);
+				$url             = $connection_setting->get_option_parent()->get_component()->get_url();
 				$link            = '<a href="' . esc_url( $url ) . '">' . __( 'Connect', 'cloudinary' ) . '</a> ';
 				$this->notices[] = array(
 					'message'     => $link . __( 'your Cloudinary account with WordPress to get started.', 'cloudinary' ),
@@ -847,7 +842,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 							),
 							array(
 								'placeholder'  => 'cloudinary://API_KEY:API_SECRET@CLOUD_NAME',
-								'slug'         => 'cloudinary_url',
+								'slug'         => self::META_KEYS['url'],
 								'title'        => __( 'Connection string', 'cloudinary' ),
 								'tooltip_text' => __(
 									'The connection string is made up of your Cloudinary Cloud name, API Key and API Secret and known as the API Environment Variable. This authenticates the Cloudinary WordPress plugin with your Cloudinary account.',

--- a/php/settings/class-setting.php
+++ b/php/settings/class-setting.php
@@ -102,10 +102,12 @@ class Setting {
 	protected function register_with_root() {
 		if ( ! $this->is_root_setting() ) {
 			// Add to root index.
-			$root                       = $this->get_root_setting();
-			$index                      = $root->get_param( 'index', array() );
-			$index[ $this->get_slug() ] = $this;
-			$root->set_param( 'index', $index );
+			$root  = $this->get_root_setting();
+			$index = $root->get_param( 'index', array() );
+			if ( ! isset( $index[ $this->get_slug() ] ) ) {
+				$index[ $this->get_slug() ] = $this;
+				$root->set_param( 'index', $index );
+			}
 		}
 	}
 

--- a/php/ui/component/class-switch-cloud.php
+++ b/php/ui/component/class-switch-cloud.php
@@ -27,11 +27,9 @@ class Switch_Cloud extends Submit {
 
 		$url = add_query_arg(
 			array(
-				'page'           => 'dashboard',
-				'tab'            => 'connect',
 				'switch-account' => true,
 			),
-			admin_url( 'admin.php' )
+			$this->setting->get_option_parent()->get_component()->get_url()
 		);
 
 		$struct['element']             = 'a';


### PR DESCRIPTION
A defect in over-registering settings resulting in a `null` component when requested, which made the `get_url` method to return null. Hence the URL being the same as the current page.

The result is to check that the setting hasn't already been set first.
Additionally, removed the direct calling to the `cloudinary_url` setting by name as well, as the the direct calling of `connect` setting. This would be a technical debt if the settings pages got moved around.
Instead, we use the primary URL setting key as a constant and fetch the settings option parent. 
This will always return the setting page, where the `get_url` will point to wherever the setting is located.