### PR TITLE
Keep the public_id updated with suffix

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1477,7 +1477,7 @@ class Media extends Settings_Component implements Setup {
 
 		$sync_key = $asset['sync_key'];
 		// Capture public_id. Use core update_post_meta since this attachment data doesnt exist yet.
-		$this->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
+		update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
 		// Capture version number.
 		$this->update_post_meta( $attachment_id, Sync::META_KEYS['version'], $asset['version'] );
 		if ( ! empty( $asset['transformations'] ) ) {

--- a/php/sync/class-upload-sync.php
+++ b/php/sync/class-upload-sync.php
@@ -157,14 +157,11 @@ class Upload_Sync {
 		switch ( $action ) {
 			case 'cloudinary-push':
 				foreach ( $post_ids as $post_id ) {
-					if ( ! $this->media->is_local_media( $post_id ) ) {
-						// Clean up for previous attempts to sync.
-						$this->sync->delete_cloudinary_meta( $post_id );
-						continue;
-					}
 					if ( ! $this->sync->is_syncable( $post_id ) ) {
 						continue;
 					}
+					// Clean up for previous syncs and start over.
+					$this->sync->delete_cloudinary_meta( $post_id );
 					$this->sync->set_signature_item( $post_id, 'file', '' );
 					$this->media->delete_post_meta( $post_id, Sync::META_KEYS['public_id'] );
 					$this->sync->add_to_sync( $post_id );

--- a/php/sync/class-upload-sync.php
+++ b/php/sync/class-upload-sync.php
@@ -271,7 +271,7 @@ class Upload_Sync {
 			// Set folder Synced.
 			$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['folder_sync'], $this->media->is_folder_synced( $attachment_id ) );
 			// Set public_id.
-			$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
+			update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $public_id );
 			// Set version.
 			$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['version'], $result['version'] );
 			// Set the delivery type.
@@ -307,7 +307,7 @@ class Upload_Sync {
 
 		if ( ! is_wp_error( $result ) ) {
 			$this->sync->set_signature_item( $attachment_id, $type );
-			$this->media->update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $options['public_id'] );
+			update_post_meta( $attachment_id, Sync::META_KEYS['public_id'], $options['public_id'] );
 		}
 
 		return $result;


### PR DESCRIPTION
- Ensures that `public_id` keeps the suffix on duplicated items;
- Allows forcing upload the asset;