### PR TITLE
Include the `cld_param` transformations on default breakpoints

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1075,6 +1075,7 @@ class Delivery implements Setup {
 				// Check overwrite.
 				$meta['overwrite_transformations'] = $tag_element['overwrite_transformations'];
 				$meta['cloudinary_id']             = $tag_element['atts']['data-public-id'];
+				$meta['transformations']           = $tag_element['transformations'];
 				// Add new srcset.
 				$element = wp_image_add_srcset_and_sizes( $tag_element['original'], $meta, $tag_element['id'] );
 

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1707,9 +1707,14 @@ class Media extends Settings_Component implements Setup {
 			return $sources; // Return WordPress default sources.
 		}
 		// Get transformations if any.
-		$transformations = $this->get_post_meta( $attachment_id, Sync::META_KEYS['transformation'], true );
-		// Use Cloudinary breakpoints for same ratio.
+		$transformations = (array) $this->get_post_meta( $attachment_id, Sync::META_KEYS['transformation'], true );
 
+		// For cases where transformations are added via cld_params.
+		if ( ! empty( $image_meta['transformations'] ) ) {
+			$transformations = array_filter( array_merge( $transformations, $image_meta['transformations'] ) );
+		}
+
+		// Use Cloudinary breakpoints for same ratio.
 		$image_meta['overwrite_transformations'] = ! empty( $image_meta['overwrite_transformations'] ) ? $image_meta['overwrite_transformations'] : false;
 
 		if ( 'on' === $this->settings->get_setting( 'enable_breakpoints' )->get_value() && wp_image_matches_ratio( $image_meta['width'], $image_meta['height'], $size_array[0], $size_array[1] ) ) {


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
Fixes transformations on default breakpoint

## QA notes

- Add an image that includes transformations via the `cld_params` and disable responsive images and well as the lazy load.
