### PR TITLE
The `secure_distribution` is a required argument when `cname` is set.

### DIFF
--- a/php/media/class-video.php
+++ b/php/media/class-video.php
@@ -329,13 +329,10 @@ class Video {
 		// Add cname if present.
 		if ( ! empty( $this->media->credentials['cname'] ) ) {
 			$params['cloudinary'] = array(
-				'cname'       => $this->media->credentials['cname'],
-				'private_cdn' => $this->media->credentials['private_cdn'],
+				'cname'               => $this->media->credentials['cname'],
+				'private_cdn'         => $this->media->credentials['private_cdn'],
+				'secure_distribution' => $this->media->credentials['cname'],
 			);
-
-			if ( 'false' === $params['cloudinary']['private_cdn'] ) {
-				$params['cloudinary']['secure_distribution'] = $this->media->credentials['cname'];
-			}
 		}
 		// Set the autoplay.
 		// Some browsers require Autoplay to be muted — https://developers.google.com/web/updates/2016/07/autoplay.


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
Fixes the Cloudinary URL for `cname` accounts when using the Cloudinary video player.


## QA notes

- Set the Cloudinary video player, and publish a post with a video. The URL inside the iframe should respect the set cname.
