### PR TITLE
Alt text does not belong to Cloudinary meta

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1931,7 +1931,7 @@ class Media extends Settings_Component implements Setup {
 		// Capture the ALT Text.
 		if ( ! empty( $asset['meta']['alt'] ) ) {
 			$alt_text = wp_strip_all_tags( $asset['meta']['alt'] );
-			$this->update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
 		}
 
 		return $attachment_id;


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
On new imports, the ALT isn't being added as proper meta. Instead, it goes as Cloudinary meta.

## QA notes

- On Cloudinary DAM, choose an image containing caption and alt text that WordPress doesn't yet manage;
- Import that image into WordPress;
- The newly imported image should bring the caption and alt text as expected.
