### PR TITLE
Support spaces folder name

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -242,6 +242,8 @@ class Delivery implements Setup {
 				$working_content = $unslash_maybe;
 			}
 		}
+		// Sometimes, synced folders contains spaces. For properly extract URLs, we need to replace the spaces with %20.
+		$working_content = str_replace( ' ', '%20', $working_content );
 		$base_urls       = array_unique( Utils::extract_urls( $working_content ) );
 		$cloudinary_urls = array_filter( $base_urls, array( $this->media, 'is_cloudinary_url' ) ); // clean out empty urls.
 		$urls            = array();
@@ -251,6 +253,9 @@ class Delivery implements Setup {
 		foreach ( $cloudinary_urls as $url ) {
 			$public_id          = $this->media->get_public_id_from_url( $url );
 			$urls[ $public_id ] = $url;
+
+			// Ensure that the encoded spaces are reverted back to.
+			$urls[ rawurldecode( $public_id ) ] = rawurldecode( $url );
 		}
 
 		$results = $this->query_relations( array_keys( $urls ) );

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -242,8 +242,6 @@ class Delivery implements Setup {
 				$working_content = $unslash_maybe;
 			}
 		}
-		// Sometimes, synced folders contains spaces. For properly extract URLs, we need to replace the spaces with %20.
-		$working_content = str_replace( ' ', '%20', $working_content );
 		$base_urls       = array_unique( Utils::extract_urls( $working_content ) );
 		$cloudinary_urls = array_filter( $base_urls, array( $this->media, 'is_cloudinary_url' ) ); // clean out empty urls.
 		$urls            = array();
@@ -253,9 +251,6 @@ class Delivery implements Setup {
 		foreach ( $cloudinary_urls as $url ) {
 			$public_id          = $this->media->get_public_id_from_url( $url );
 			$urls[ $public_id ] = $url;
-
-			// Ensure that the encoded spaces are reverted back to.
-			$urls[ rawurldecode( $public_id ) ] = rawurldecode( $url );
 		}
 
 		$results = $this->query_relations( array_keys( $urls ) );

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1298,7 +1298,7 @@ class Media extends Settings_Component implements Setup {
 			$url
 		);
 
-		return $cache[ $key ];
+		return esc_url( $cache[ $key ] );
 	}
 
 	/**

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -659,6 +659,11 @@ class Media extends Settings_Component implements Setup {
 			}
 		}
 
+		// Bail on incomplete url.
+		if ( empty( $parts ) ) {
+			return null;
+		}
+
 		// The remaining items should be the file.
 		$file      = implode( '/', $parts );
 		$path_info = Utils::pathinfo( $file );

--- a/php/class-relate.php
+++ b/php/class-relate.php
@@ -46,7 +46,7 @@ class Relate {
 	 */
 	protected function register_hooks() {
 		add_action( 'cloudinary_upgrade_asset', array( $this, 'upgrade_relation' ), 10, 2 );
-		add_action( 'found_posts', array( $this, 'warm_cache' ), 10, 2 );
+		add_filter( 'found_posts', array( $this, 'warm_cache' ), 10, 2 );
 	}
 
 	/**
@@ -54,11 +54,15 @@ class Relate {
 	 *
 	 * @param int      $found_posts The number of posts found.
 	 * @param WP_Query $query       The WP_Query instance (passed by reference).
+	 *
+	 * @return int
 	 */
 	public function warm_cache( $found_posts, $query ) {
 		if ( ! empty( $found_posts ) && 'attachment' === $query->query_vars['post_type'] ) {
 			Relationship::preload( $query->posts );
 		}
+
+		return $found_posts;
 	}
 
 	/**


### PR DESCRIPTION
When the Cloudinary sync folder contains spaces in its name, the filter out of Cloudinary URLs fails to detect the full URL for the image, corrupting the data stored in the DB.

