### PR TITLE
Fix WPVIP feedback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "^2.3",
-    "automattic/vipwpcs": "^2.2",
+    "automattic/vipwpcs": "dev-develop",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "phpcompatibility/phpcompatibility-wp": "dev-master",
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efc23825d99d83a4c22fa74dbc200ddf",
+    "content-hash": "b75fd672f09ec72443a3abdfb04d75d6",
     "packages": [],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "df070e7c6f6dbe0973a509c9829c6ae163fd735e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/df070e7c6f6dbe0973a509c9829c6ae163fd735e",
+                "reference": "df070e7c6f6dbe0973a509c9829c6ae163fd735e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
+                "squizlabs/php_codesniffer": "^3.7.1",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -50,6 +51,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -57,7 +59,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-06-24T09:52:29+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -140,30 +142,29 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "c23e20c0aaa5c527fd7b3fbef38c50c458bb47f1"
+                "reference": "3a363ebda5075161128619d4c84a1f8ab3e37680"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/c23e20c0aaa5c527fd7b3fbef38c50c458bb47f1",
-                "reference": "c23e20c0aaa5c527fd7b3fbef38c50c458bb47f1",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/3a363ebda5075161128619d4c84a1f8ab3e37680",
+                "reference": "3a363ebda5075161128619d4c84a1f8ab3e37680",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^2.6 || ^3.1.0"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
             "replace": {
                 "wimg/php-compatibility": "*"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.8 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || >=9.0 <9.3.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
             },
             "suggest": {
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
@@ -201,26 +202,27 @@
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
-            "time": "2022-04-14T19:54:29+00:00"
+            "time": "2023-06-26T10:52:01+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -257,26 +259,27 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+                "reference": "262f9d81273932315d15d704f69b9d678b939cb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/262f9d81273932315d15d704f69b9d678b939cb3",
+                "reference": "262f9d81273932315d15d704f69b9d678b939cb3",
                 "shasum": ""
             },
             "require": {
@@ -284,12 +287,13 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -311,13 +315,14 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-12-30T16:37:40+00:00"
+            "time": "2023-01-05T13:34:27+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -325,34 +330,31 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "b65fbd47c38202a667ea3930a4a51c5c8b9ca434"
+                "reference": "87630f9be25f94295687980c61b61ff4e9ea06f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/b65fbd47c38202a667ea3930a4a51c5c8b9ca434",
-                "reference": "b65fbd47c38202a667ea3930a4a51c5c8b9ca434",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87630f9be25f94295687980c61b61ff4e9ea06f6",
+                "reference": "87630f9be25f94295687980c61b61ff4e9ea06f6",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.6.0 || ^3.1.0 || 4.0.x-dev@dev"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "3.5.3"
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-                "yoast/phpunit-polyfills": "^1.0.1"
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
             },
             "default-branch": true,
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev",
+                    "dev-stable": "1.x-dev",
                     "dev-develop": "1.x-dev"
                 }
             },
@@ -383,9 +385,9 @@
                 "phpcbf",
                 "phpcodesniffer-standard",
                 "phpcs",
-                "phpcs2",
                 "phpcs3",
                 "standards",
+                "static analysis",
                 "tokens",
                 "utility"
             ],
@@ -394,7 +396,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2022-06-30T21:20:54+00:00"
+            "time": "2023-06-26T10:35:06+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -402,12 +404,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "274711644a647844ea19c5ff7f6daa5321aacd04"
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/274711644a647844ea19c5ff7f6daa5321aacd04",
-                "reference": "274711644a647844ea19c5ff7f6daa5321aacd04",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
                 "shasum": ""
             },
             "require": {
@@ -415,7 +417,7 @@
                 "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
@@ -444,12 +446,16 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2022-07-25T17:19:42+00:00"
+            "time": "2023-03-31T16:46:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -457,12 +463,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f3a83428055642b09d14ec216ceae7107817c117"
+                "reference": "d148febc2a2eb82972121d7f962883f7a5697b55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f3a83428055642b09d14ec216ceae7107817c117",
-                "reference": "f3a83428055642b09d14ec216ceae7107817c117",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d148febc2a2eb82972121d7f962883f7a5697b55",
+                "reference": "d148febc2a2eb82972121d7f962883f7a5697b55",
                 "shasum": ""
             },
             "require": {
@@ -499,14 +505,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-27T22:52:37+00:00"
+            "time": "2023-05-26T22:32:02+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -570,6 +577,8 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/vipwpcs": 20,
+        "phpcompatibility/phpcompatibility-wp": 20,
         "phpcompatibility/php-compatibility": 20
     },
     "prefer-stable": false,

--- a/php/cache/class-cache-point.php
+++ b/php/cache/class-cache-point.php
@@ -976,6 +976,6 @@ class Cache_Point {
 			'rewrite'             => false,
 			'capability_type'     => 'page',
 		);
-		$this->post_type = register_post_type( self::POST_TYPE_SLUG, $args );
+		$this->post_type = register_post_type( self::POST_TYPE_SLUG, $args ); // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.NotStringLiteral
 	}
 }

--- a/php/cache/class-cache-point.php
+++ b/php/cache/class-cache-point.php
@@ -869,9 +869,13 @@ class Cache_Point {
 				foreach ( $indexes as $key ) {
 					$url = $urls[ $key ];
 
-					if ( ! isset( $meta[ self::META_KEYS['cached_urls'] ][ $url ] )
-						 || $url === $meta[ self::META_KEYS['cached_urls'] ][ $url ]
-							&& $meta[ self::META_KEYS['last_updated'] ] < time() - MINUTE_IN_SECONDS * 10 ) {
+					if (
+						! isset( $meta[ self::META_KEYS['cached_urls'] ][ $url ] )
+						|| (
+							$url === $meta[ self::META_KEYS['cached_urls'] ][ $url ]
+							&& $meta[ self::META_KEYS['last_updated'] ] < time() - MINUTE_IN_SECONDS * 10
+						)
+					) {
 						// Send to upload prep.
 						$this->prepare_for_sync( $post->ID );
 						$meta[ self::META_KEYS['cached_urls'] ][ $url ] = $url;

--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -1156,7 +1156,7 @@ class Assets extends Settings_Component {
 			'rewrite'             => false,
 			'capability_type'     => 'page',
 		);
-		$this->post_type = register_post_type( self::POST_TYPE_SLUG, $args );
+		$this->post_type = register_post_type( self::POST_TYPE_SLUG, $args ); // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.NotStringLiteral
 	}
 
 	/**

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -356,6 +356,7 @@ class Media extends Settings_Component implements Setup {
 		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
 			return false;
 		}
+		// phpcs:disable WordPress.WP.AlternativeFunctions
 		$ch = curl_init( $url );
 		curl_setopt( $ch, CURLOPT_NOBODY, true );
 		curl_exec( $ch );
@@ -368,6 +369,7 @@ class Media extends Settings_Component implements Setup {
 		}
 
 		curl_close( $ch );
+		// phpcs:enable
 
 		return $status;
 	}
@@ -3033,13 +3035,15 @@ class Media extends Settings_Component implements Setup {
 			if ( SYNC::META_KEYS['unsynced'] === $request ) {
 				global $wpdb;
 				$wpdb->cld_table = Utils::get_relationship_table();
-				$result          = $wpdb->get_col( "SELECT post_id FROM $wpdb->cld_table WHERE public_id IS NULL" );
+				$result          = $wpdb->get_col( "SELECT post_id FROM $wpdb->cld_table WHERE public_id IS NULL" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
+				// phpcs:disable WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 				if ( ! empty( $result ) ) {
 					$query->set( 'post__in', $result );
 				} else {
 					$query->set( 'post__in', array( 0 ) );
 				}
+				// phpcs:enable
 			}
 		}
 	}

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -992,8 +992,8 @@ class Media extends Settings_Component implements Setup {
 	 */
 	public function get_crop_transformations( $attachment_id, $size ) {
 		static $transformations = array();
-		$size_dim = $size['width'] . 'x' . $size['height'];
-		$key      = $attachment_id . $size_dim;
+		$size_dim               = $size['width'] . 'x' . $size['height'];
+		$key                    = $attachment_id . $size_dim;
 		if ( empty( $transformations[ $key ] ) ) {
 
 			if ( empty( $size['transformation'] ) ) {

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -190,7 +190,7 @@ final class Plugin {
 
 		foreach ( $parts as $slug => $part ) {
 			if ( file_exists( $this->dir_path . "ui-definitions/settings-{$slug}.php" ) ) {
-				$parts[ $slug ] = include $this->dir_path . "ui-definitions/settings-{$slug}.php";
+				$parts[ $slug ] = include $this->dir_path . "ui-definitions/settings-{$slug}.php"; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 			}
 		}
 

--- a/php/class-report.php
+++ b/php/class-report.php
@@ -223,7 +223,7 @@ class Report extends Settings_Component implements Setup {
 			"SELECT * FROM {$wpdb->cld_table} WHERE post_id = %d;",
 			$post->ID
 		);
-		$relationship    = $wpdb->get_row( $prepare ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$relationship    = $wpdb->get_row( $prepare ); // phpcs:ignore WordPress.DB.PreparedSQL,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		ksort( $attachment );
 		ksort( $meta );

--- a/php/class-string-replace.php
+++ b/php/class-string-replace.php
@@ -168,7 +168,7 @@ class String_Replace implements Setup {
 		if ( defined( 'CLD_DEBUG' ) && true === CLD_DEBUG && ! Utils::get_sanitized_text( '_bypass' ) ) {
 			$this->context = 'view';
 			ob_start();
-			include $template;
+			include $template; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 			$html = ob_get_clean();
 			echo $this->replace_strings( $html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			$template = $this->plugin->template_path . 'blank-template.php';

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -923,14 +923,17 @@ class Utils {
 	 * @return int
 	 */
 	public static function attachment_url_to_postid( $url ) {
-		$attachment_id = 0;
+		$key = "postid_{$url}";
+
 		if ( function_exists( 'wpcom_vip_attachment_url_to_postid' ) ) {
 			$attachment_id = wpcom_vip_attachment_url_to_postid( $url );
+		} else {
+			$attachment_id = wp_cache_get( $key, 'cloudinary' );
 		}
 
-		if ( 0 === $attachment_id && empty( wp_cache_get( "postid_{$url}", 'cloudinary' ) ) ) {
+		if ( empty( $attachment_id ) ) {
 			$attachment_id = attachment_url_to_postid( $url ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid
-			wp_cache_set( "postid_{$url}", $attachment_id, 'cloudinary' );
+			wp_cache_set( $key, $attachment_id, 'cloudinary' );
 		}
 
 		return $attachment_id;

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -500,7 +500,7 @@ class Utils {
 		 *
 		 * @see wp-includes/formatting.php
 		 */
-		$path = str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) );
+		$path = str_replace( array( '%2F', '%5C' ), '/', urlencode( $path ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode
 
 		$pathinfo = pathinfo( $path, $flags );
 

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -914,4 +914,25 @@ class Utils {
 		 */
 		return apply_filters( 'cloudinary_registered_sizes', $all_sizes );
 	}
+
+	/**
+	 * Get the attachment ID from the attachment URL.
+	 *
+	 * @param string $url The attachment URL.
+	 *
+	 * @return int
+	 */
+	public static function attachment_url_to_postid( $url ) {
+		$attachment_id = 0;
+		if ( function_exists( 'wpcom_vip_attachment_url_to_postid' ) ) {
+			$attachment_id = wpcom_vip_attachment_url_to_postid( $url );
+		}
+
+		if ( 0 === $attachment_id && empty( wp_cache_get( "postid_{$url}", 'cloudinary' ) ) ) {
+			$attachment_id = attachment_url_to_postid( $url ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.attachment_url_to_postid_attachment_url_to_postid
+			wp_cache_set( "postid_{$url}", $attachment_id, 'cloudinary' );
+		}
+
+		return $attachment_id;
+	}
 }

--- a/php/connect/class-api.php
+++ b/php/connect/class-api.php
@@ -804,7 +804,7 @@ class Api {
 		$hostname = $upload_prefix;
 
 		if ( filter_var( $upload_prefix, FILTER_VALIDATE_URL ) ) {
-			$hostname = parse_url( $upload_prefix, PHP_URL_HOST );
+			$hostname = wp_parse_url( $upload_prefix, PHP_URL_HOST );
 		}
 
 		return $hostname;

--- a/php/media/class-filter.php
+++ b/php/media/class-filter.php
@@ -572,7 +572,7 @@ class Filter {
 	public function pre_filter_rest_content( $response, $post, $request ) {
 		$context = $request->get_param( 'context' );
 		if ( 'edit' === $context ) {
-			$data                   = $response->get_data();
+			$data = $response->get_data();
 			// Handle meta if missing due to custom-fields not being supported.
 			if ( ! isset( $data['meta'] ) ) {
 				$data['meta'] = $request->get_param( 'meta' );

--- a/php/media/class-gallery.php
+++ b/php/media/class-gallery.php
@@ -212,7 +212,7 @@ class Gallery extends Settings_Component {
 	 * @return array
 	 */
 	private function get_asset() {
-		$asset = require $this->plugin->dir_path . 'js/gallery.asset.php';
+		$asset = require $this->plugin->dir_path . 'js/gallery.asset.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 
 		$asset['dependencies'] = array_filter(
 			$asset['dependencies'],

--- a/php/media/class-video.php
+++ b/php/media/class-video.php
@@ -279,8 +279,8 @@ class Video {
 						if ( ! empty( $attributes['poster'] ) ) {
 							// Maybe local URL.
 							if ( ! $this->media->is_cloudinary_url( $attributes['poster'] ) ) {
-								$post_id = attachment_url_to_postid( $attributes['poster'] );
-								$url = $this->media->cloudinary_url( $post_id );
+								$post_id = Utils::attachment_url_to_postid( $attributes['poster'] );
+								$url     = $this->media->cloudinary_url( $post_id );
 								if ( $url ) {
 									$content = str_replace( $attributes['poster'], $url, $content );
 								}

--- a/php/media/class-video.php
+++ b/php/media/class-video.php
@@ -145,7 +145,7 @@ class Video {
 			);
 			foreach ( $supported_formats as $format ) {
 				if ( ! empty( $attr[ $format ] ) ) {
-					$attr['id'] = attachment_url_to_postid( $attr[ $format ] );
+					$attr['id'] = Utils::attachment_url_to_postid( $attr[ $format ] );
 					break;
 				}
 			}
@@ -367,7 +367,7 @@ class Video {
 
 			// Maybe poster is a local URL.
 			if ( empty( $poster_id ) ) {
-				$post_id   = attachment_url_to_postid( $attributes['poster'] );
+				$post_id   = Utils::attachment_url_to_postid( $attributes['poster'] );
 				$poster_id = $this->media->get_public_id( $post_id );
 			}
 

--- a/php/relate/class-relationship.php
+++ b/php/relate/class-relationship.php
@@ -216,7 +216,7 @@ class Relationship {
 		global $wpdb;
 
 		$table_name = Utils::get_relationship_table();
-		$ids        = $wpdb->get_col( $wpdb->prepare( "SELECT post_id FROM {$table_name} WHERE public_id = %s", $public_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$ids        = $wpdb->get_col( $wpdb->prepare( "SELECT post_id FROM {$table_name} WHERE public_id = %s", $public_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
 		return array_map( 'intval', $ids );
 	}

--- a/php/sync/class-download-sync.php
+++ b/php/sync/class-download-sync.php
@@ -224,7 +224,7 @@ class Download_Sync {
 			$http_class = ABSPATH . WPINC . '/class-wp-http.php';
 		}
 		if ( ! class_exists( 'WP_Http' ) ) {
-			require_once $http_class;
+			require_once $http_class; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		}
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		require_once ABSPATH . 'wp-admin/includes/image.php';

--- a/php/sync/class-sync-queue.php
+++ b/php/sync/class-sync-queue.php
@@ -507,6 +507,7 @@ class Sync_Queue {
 		} while ( $query->have_posts() );
 
 		$threads          = $this->add_to_queue( $ids );
+		$queue            = array();
 		$queue['total']   = array_sum( $threads );
 		$queue['threads'] = array_keys( $threads );
 		$queue['started'] = current_time( 'timestamp' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
@@ -611,7 +612,7 @@ class Sync_Queue {
 	 * @return bool
 	 */
 	public function is_autosync_thread( $thread ) {
-		return in_array( $thread, $this->autosync_threads );
+		return in_array( $thread, $this->autosync_threads, true );
 	}
 
 	/**
@@ -828,17 +829,17 @@ class Sync_Queue {
 	 */
 	public function add_to_queue( array $attachment_ids, $type = 'queue' ) {
 
-		$been_synced = array_filter( $attachment_ids, array( $this->sync, 'been_synced' ) );
-		$new_items   = array_diff( $attachment_ids, $been_synced );
-		$threads     = $this->get_threads( $type );
-		$new_thread  = array_shift( $threads );
+		$been_synced    = array_filter( $attachment_ids, array( $this->sync, 'been_synced' ) );
+		$new_items      = array_diff( $attachment_ids, $been_synced );
+		$threads        = $this->get_threads( $type );
+		$new_thread     = array_shift( $threads );
+		$active_threads = array();
 		if ( ! empty( $new_items ) ) {
 			$this->add_to_thread_queue( $new_thread, $new_items );
 			$active_threads[ $new_thread ] = count( $new_items );
 		}
 
 		$attachment_ids = $been_synced;
-		$active_threads = array();
 		if ( ! empty( $attachment_ids ) ) {
 			$chunk_size = ceil( count( $attachment_ids ) / count( $threads ) );
 			$chunks     = array_chunk( $attachment_ids, $chunk_size );

--- a/php/traits/trait-cli.php
+++ b/php/traits/trait-cli.php
@@ -466,11 +466,12 @@ trait CLI_Trait {
 	 * @return void
 	 */
 	protected function export_csv( $data, $type ) {
-		$filename = sanitize_file_name( 'cloudinary-' . $type . '-' . time() . '.csv' );
-		$fp       = fopen( $filename, 'wb+' );
+		$upload   = wp_get_upload_dir();
+		$filename = trailingslashit( $upload['path'] ) . sanitize_file_name( 'cloudinary-' . $type . '-' . time() . '.csv' );
+		$fp       = fopen( $filename, 'wb+' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 
 		foreach ( $data as $fields ) {
-			fputcsv( $fp, $fields );
+			fputcsv( $fp, $fields ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_fputcsv
 		}
 
 		fclose( $fp );

--- a/php/ui/component/class-info-box.php
+++ b/php/ui/component/class-info-box.php
@@ -68,7 +68,7 @@ class Info_Box extends Panel {
 	 */
 	protected function wrap( $struct ) {
 		$struct = parent::wrap( $struct );
-		unset( $struct['attributes']['class'][ array_search( 'has-heading', $struct['attributes']['class'] ) ] );
+		unset( $struct['attributes']['class'][ array_search( 'has-heading', $struct['attributes']['class'], true ) ] );
 
 		return $struct;
 	}

--- a/php/ui/component/class-notice.php
+++ b/php/ui/component/class-notice.php
@@ -58,7 +58,7 @@ class Notice extends Component {
 	 * @return array
 	 */
 	protected function icon( $struct ) {
-		$struct['element'] = 'span';
+		$struct['element']             = 'span';
 		$struct['attributes']['class'] = array( 'cld-ui-icon' );
 		if ( $this->setting->has_param( 'icon' ) ) {
 			$struct['attributes']['class'][] = $this->setting->get_param( 'icon' );

--- a/php/ui/component/class-table.php
+++ b/php/ui/component/class-table.php
@@ -129,8 +129,8 @@ class Table extends Text {
 	 */
 	protected function body_row( $slug, $row ) {
 		$next_colspan = 1;
-
-		$columns = array();
+		$columns      = array();
+		$previous     = null;
 		foreach ( $this->columns as $column ) {
 
 			$col_slug                     = $slug . '_' . $column;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,6 +15,7 @@
 	<arg name="extensions" value="php" />
 	<arg name="colors" />
 	<arg value="s" /><!-- Show sniff codes in all reports. -->
+	<arg name="severity" value="3" /><!-- Match WPVIP requirements. -->
 
 	<!-- Includes WordPress-Core, WordPress-Docs and WordPress-Extra rulesets. -->
 	<rule ref="WordPress" />

--- a/ui-definitions/components/wizard.php
+++ b/ui-definitions/components/wizard.php
@@ -152,7 +152,7 @@ $advanced->set_value( 'on' );
 						<span class="spinner"></span>
 					</span>
 				</div>
-				<?php require $cloudinary->dir_path . 'php/templates/connection-string.php'; ?>
+				<?php require $cloudinary->dir_path . 'php/templates/connection-string.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable ?>
 			</div>
 		</div>
 		<div class="cld-wizard-content cld-wizard-optimize hidden" id="tab-3">

--- a/ui-definitions/settings-image.php
+++ b/ui-definitions/settings-image.php
@@ -150,7 +150,7 @@ $settings = array(
 						'type'           => 'text',
 						'slug'           => 'image_freeform',
 						'title'          => __( 'Additional image transformations', 'cloudinary' ),
-						'default'       => '',
+						'default'        => '',
 						'tooltip_text'   => sprintf(
 						// translators: The link to transformation reference.
 							__(

--- a/ui-definitions/settings-pages.php
+++ b/ui-definitions/settings-pages.php
@@ -71,7 +71,7 @@ $settings = array(
 		'priority'            => 5,
 		'requires_connection' => true,
 		'sidebar'             => true,
-		'settings'            => include $this->dir_path . 'ui-definitions/settings-image.php',
+		'settings'            => include $this->dir_path . 'ui-definitions/settings-image.php', // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 	),
 	'video_settings' => array(
 		'page_title'          => __( 'Video settings', 'cloudinary' ),
@@ -79,7 +79,7 @@ $settings = array(
 		'priority'            => 5,
 		'requires_connection' => true,
 		'sidebar'             => true,
-		'settings'            => include $this->dir_path . 'ui-definitions/settings-video.php',
+		'settings'            => include $this->dir_path . 'ui-definitions/settings-video.php', // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 	),
 	'lazy_loading'   => array(),
 	'responsive'     => array(

--- a/ui-definitions/settings-pages.php
+++ b/ui-definitions/settings-pages.php
@@ -433,14 +433,14 @@ $settings = array(
 		'section' => 'wizard',
 		'slug'    => 'wizard',
 	),
-	'debug'         => array(
+	'debug'          => array(
 		'section' => 'debug',
 		'slug'    => 'debug',
 		array(
 			'type'  => 'panel',
 			'title' => __( 'Debug log', 'cloudinary' ),
 			array(
-				'type'    => 'debug',
+				'type' => 'debug',
 			),
 		),
 	),

--- a/ui-definitions/settings-video.php
+++ b/ui-definitions/settings-video.php
@@ -202,7 +202,7 @@ $settings = array(
 						'type'           => 'text',
 						'slug'           => 'video_freeform',
 						'title'          => __( 'Additional video transformations', 'cloudinary' ),
-						'default'       => '',
+						'default'        => '',
 						'tooltip_text'   => sprintf(
 							// translators: The link to transformation reference.
 							__(


### PR DESCRIPTION
This PR addresses some warnings seen on WPVIP.

Aside from minor spacing fixes and alike, it also introduces the following:
- `Utils::attachment_url_to_postid` — a wrapper for `wpcom_vip_attachment_url_to_postid` or use `wp_cache` to store this information. This should have a positive impact on performance;
- fixes on `export_csv` for the CLI commands, which due to the VIP filesystem, could result in an impossibility of storing the export data;
- Increases the sensibility of the PHPCS so that we can sooner spot these issues;