### PR TITLE
Declare variable

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -83,6 +83,13 @@ final class Plugin {
 	public $dir_url;
 
 	/**
+	 * The plugin file.
+	 *
+	 * @var string
+	 */
+	protected $plugin_file;
+
+	/**
 	 * Directory in plugin containing autoloaded classes.
 	 *
 	 * @var string


### PR DESCRIPTION
PHP has deprecated dynamically created properties, and it's now throwing a warning.