### PR TITLE
Hotfix/3.1.6 build 2

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1583,9 +1583,22 @@ class Delivery implements Setup {
 
 		$content_url = content_url();
 
+		/**
+		 * The URL to be searched for and prepared to be delivered by Cloudinary.
+		 *
+		 * @hook   cloudinary_delivery_searchable_url
+		 * @since  3.1.6
+		 *
+		 * @param $url         {string} The URL to be searched for and prepared to be delivered by Cloudinary.
+		 * @param $item        {array}  The found asset array.
+		 * @param $content_url {string} The content URL.
+		 *
+		 * @return {string}
+		 */
+		$url = apply_filters( 'cloudinary_delivery_searchable_url', Utils::clean_url( $content_url ) . $item['sized_url'], $item, $content_url );
+
 		$found                       = array();
 		$found[ $item['public_id'] ] = $item;
-		$url                         = Utils::clean_url( $content_url ) . $item['sized_url'];
 		$scaled                      = Utils::make_scaled_url( $url );
 		$descaled                    = Utils::descaled_url( $url );
 		$scaled_slashed              = addcslashes( $scaled, '/' );

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -402,7 +402,7 @@ class Delivery implements Setup {
 		}
 
 		if ( empty( $sized_url ) ) {
-			$sized_url = Utils::clean_url( wp_get_attachment_url( $attachment_id ), true );
+			$sized_url = Utils::get_path_from_url( wp_get_attachment_url( $attachment_id ), true );
 		}
 		self::create_size_relation( $attachment_id, $sized_url, $wh, $base );
 		// Update public ID and type.

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -522,7 +522,7 @@ class Delivery implements Setup {
 	 * @param int    $attachment_id The attachment ID.
 	 * @param string $public_id     The public ID.
 	 */
-	public static function update_size_relations_public_id( $attachment_id, $public_id ) {
+	public static function update_size_relations_public_id( $attachment_id, $public_id = '' ) {
 		$relationship = Relationship::get_relationship( $attachment_id );
 
 		if ( $relationship instanceof Relationship ) {
@@ -1145,7 +1145,7 @@ class Delivery implements Setup {
 				$local_size = filesize( get_attached_file( $tag_element['id'] ) );
 			}
 			$remote_size                           = get_post_meta( $tag_element['id'], Sync::META_KEYS['remote_size'], true );
-			$tag_element['atts']['data-filesize']   = size_format( $local_size );
+			$tag_element['atts']['data-filesize']  = size_format( $local_size );
 			$tag_element['atts']['data-optsize']   = size_format( $remote_size );
 			$tag_element['atts']['data-optformat'] = get_post_meta( $tag_element['id'], Sync::META_KEYS['remote_format'], true );
 			if ( ! empty( $local_size ) && ! empty( $remote_size ) ) {

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1633,7 +1633,7 @@ class Delivery implements Setup {
 			$this->sync->add_to_sync( $item['post_id'] );
 		} elseif ( true === $auto_sync && true === $is_media && empty( $item['public_id'] ) ) {
 			// Un-synced media item with auto sync on. Add to sync.
-			$this->sync->add_to_sync( (int) $item['post_id'] );
+			$this->sync->add_to_sync( $item['post_id'] );
 		} elseif ( ! empty( $item['public_id'] ) ) {
 			// Most likely an asset with a public ID.
 			$this->usable[ $url ] = $url;

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1597,8 +1597,12 @@ class Delivery implements Setup {
 		 */
 		$url = apply_filters( 'cloudinary_delivery_searchable_url', Utils::clean_url( $content_url ) . $item['sized_url'], $item, $content_url );
 
-		$found                       = array();
-		$found[ $item['public_id'] ] = $item;
+		$found = array();
+
+		// If there's no public ID then don't pollute the found items.
+		if ( ! empty( $item['public_id'] ) ) {
+			$found[ $item['public_id'] ] = $item;
+		}
 		$scaled                      = Utils::make_scaled_url( $url );
 		$descaled                    = Utils::descaled_url( $url );
 		$scaled_slashed              = addcslashes( $scaled, '/' );

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -519,15 +519,15 @@ class Delivery implements Setup {
 	/**
 	 * Update relationship public ID.
 	 *
-	 * @param int    $attachment_id The attachment ID.
-	 * @param string $public_id     The public ID.
+	 * @param int         $attachment_id The attachment ID.
+	 * @param null|string $public_id     The public ID.
 	 */
-	public static function update_size_relations_public_id( $attachment_id, $public_id = '' ) {
+	public static function update_size_relations_public_id( $attachment_id, $public_id ) {
 		$relationship = Relationship::get_relationship( $attachment_id );
 
 		if ( $relationship instanceof Relationship ) {
 			$relationship->public_id   = $public_id;
-			$relationship->public_hash = md5( $public_id );
+			$relationship->public_hash = md5( (string) $public_id );
 			$relationship->signature   = self::get_settings_signature();
 			$relationship->save();
 		}

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1633,7 +1633,7 @@ class Delivery implements Setup {
 			$this->sync->add_to_sync( $item['post_id'] );
 		} elseif ( true === $auto_sync && true === $is_media && empty( $item['public_id'] ) ) {
 			// Un-synced media item with auto sync on. Add to sync.
-			$this->sync->add_to_sync( $item['post_id'] );
+			$this->sync->add_to_sync( (int) $item['post_id'] );
 		} elseif ( ! empty( $item['public_id'] ) ) {
 			// Most likely an asset with a public ID.
 			$this->usable[ $url ] = $url;

--- a/php/class-meta-box.php
+++ b/php/class-meta-box.php
@@ -74,7 +74,11 @@ class Meta_Box {
 		$media = $this->plugin->get_component( 'media' );
 		if ( wp_attachment_is_image( $post ) ) {
 			$public_id     = $media->get_public_id( $post->ID );
-			$file_id       = basename( $media->get_cloudinary_id( $post->ID ) );
+			$cloudinary_id = $media->get_cloudinary_id( $post->ID );
+			if ( empty( $cloudinary_id ) ) {
+				$cloudinary_id = '';
+			}
+			$file_id       = basename( $cloudinary_id );
 			$cloudinary_id = path_join( $public_id, $file_id );
 		} else {
 			$cloudinary_id = $media->get_cloudinary_id( $post->ID );

--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -999,7 +999,7 @@ class Sync implements Setup, Assets {
 	 * @param int $attachment_id The attachment ID to add.
 	 */
 	public function add_to_sync( $attachment_id ) {
-		if ( ! in_array( $attachment_id, $this->to_sync, true ) ) {
+		if ( ! in_array( (int) $attachment_id, $this->to_sync, true ) ) {
 
 			// There are cases where we do not check can_sync. This is to make sure we don't add to the to_sync array if we can't sync.
 			if ( ! $this->plugin->get_component( 'delivery' )->is_deliverable( $attachment_id ) ) {

--- a/php/connect/class-api.php
+++ b/php/connect/class-api.php
@@ -591,7 +591,7 @@ class Api {
 			 * it's likely due to CURL or the location does not support URL file attachments.
 			 * In this case, we'll flag and disable it and try again with a local file.
 			 */
-			if ( 404 !== $code && empty( $disable_https_fetch ) && false !== strpos( $error, $args['file'] ) ) {
+			if ( 404 !== $code && empty( $disable_https_fetch ) && false !== strpos( urldecode( $error ), $args['file'] ) ) {
 				// URLS are not remotely available, try again as a file.
 				set_transient( '_cld_disable_http_upload', true, DAY_IN_SECONDS );
 				// Remove URL file.

--- a/php/sync/class-storage.php
+++ b/php/sync/class-storage.php
@@ -391,6 +391,14 @@ class Storage implements Notice {
 	 * @param string $public_id     Optional public ID.
 	 */
 	public function size_sync( $attachment_id, $public_id = null ) {
+		if ( is_null( $public_id ) ) {
+			$public_id = $this->media->get_public_id( $attachment_id );
+		}
+
+		if ( is_null( $public_id ) ) {
+			return;
+		}
+
 		$args      = array(
 			/** This filter is documented in wp-includes/class-wp-http-streams.php */
 			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),


### PR DESCRIPTION
Fixes a couple of PHP 8.2 warnings when dealing with unsynced assets.
Adds a filter to tweak the searchable URLs on the Delivery class