### PR TITLE
Fix closing the filestream and deleting the fragment

### DIFF
--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -670,7 +670,10 @@ class Utils {
 			if ( empty( $index ) ) {
 				add_action( 'shutdown', array( __CLASS__, 'purge_fragments' ) );
 			}
-			self::$file_fragments[ $index ] = $temp_file;
+			self::$file_fragments[ $index ] = array(
+				'pointer' => $pointer,
+				'file'    => $temp_file,
+			);
 			// Get the metadata of the stream.
 			$data = stream_get_meta_data( $pointer );
 			// Stream the content to the temp file.
@@ -710,8 +713,8 @@ class Utils {
 	 */
 	public static function purge_fragment( $index ) {
 		if ( isset( self::$file_fragments[ $index ] ) ) {
-			fclose( self::$file_fragments[ $index ] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
-			unset( self::$file_fragments[ $index ] );
+			fclose( self::$file_fragments[ $index ]['pointer'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+			unlink( self::$file_fragments[ $index ]['file'] );
 		}
 	}
 


### PR DESCRIPTION
Fixes the removal of unnecessary fragments.


## Approach

- Fixes the closing of the file stream;
- Fixes the function to delete the file from the file system


## QA notes

- Download an asset from Cloudinary DAM into WordPress;
- Visit the temp folder — usually `/var/tmp/` or `/tmp/`;
- Confirm that there isn't a file with the following pattern:
  - Original filename: `image.jpg`;
  - Temporary file: `image-XsWqIe.tmp` — filename suffixed with 6 random chars and the file extension tmp.
