### PR TITLE
Prevent the duplication of Cloudinary's analytics query arg

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1016,11 +1016,13 @@ class Delivery implements Setup {
 				continue;
 			}
 			if ( ! empty( $relation['slashed'] ) && $relation['slashed'] ) {
-				$aliases[ $base . '?' ] = addcslashes( $cloudinary_url . '&', '/' );
-				$aliases[ $base ]       = addcslashes( $cloudinary_url, '/' );
+				$aliases[ $base . '?_i=AA' ] = addcslashes( $cloudinary_url, '/' );
+				$aliases[ $base . '?' ]      = addcslashes( $cloudinary_url . '&', '/' );
+				$aliases[ $base ]            = addcslashes( $cloudinary_url, '/' );
 			} else {
-				$aliases[ $base . '?' ] = $cloudinary_url . '&';
-				$aliases[ $base ]       = $cloudinary_url;
+				$aliases[ $base . '?_i=AA' ] = $cloudinary_url;
+				$aliases[ $base . '?' ]      = $cloudinary_url . '&';
+				$aliases[ $base ]            = $cloudinary_url;
 			}
 		}
 


### PR DESCRIPTION

## Approach

- By prepending the base URL with Cloudinary's query argument in the search alias array, we'll ensure that it will try first to replace the URLs where this argument is part of the existing URL.

