### PR TITLE
fix: prevent php warning in looks_like_json function

### DIFF
--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -543,7 +543,21 @@ class Utils {
 	 * @return bool
 	 */
 	public static function looks_like_json( $thing ) {
-		return is_string( $thing ) && ! empty( ltrim( $thing ) ) && in_array( $thing[0], array( '{', '[' ), true );
+		if ( ! is_string( $thing ) ) {
+			return false;
+		}
+
+		$thing = trim( $thing );
+	
+		if ( empty( $thing ) ) {
+			return false;
+		}
+	
+		if ( ! in_array( $thing[0], array( '{', '[' ), true ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -543,7 +543,7 @@ class Utils {
 	 * @return bool
 	 */
 	public static function looks_like_json( $thing ) {
-		return ! empty( $thing ) && is_string( $thing ) && in_array( ltrim( $thing )[0], array( '{', '[' ), true );
+		return is_string( $thing ) && ! empty( ltrim( $thing ) ) && in_array( $thing[0], array( '{', '[' ), true );
 	}
 
 	/**


### PR DESCRIPTION
If `$thing` only contains a `space` it will generate a php warning when doing `ltrim( $thing )[0]`. This fixes the issue while still being compatible with php 5.4+.

Fixes issue #933
