### PR TITLE
Fix: Responsive breakpoints

### DIFF
--- a/php/delivery/class-responsive-breakpoints.php
+++ b/php/delivery/class-responsive-breakpoints.php
@@ -140,7 +140,7 @@ class Responsive_Breakpoints extends Delivery_Feature {
 		$size_transformation = $this->media->get_crop_from_transformation( $this->media->get_transformations_from_string( $src ) );
 		$size_string         = Api::generate_transformation_string( array( $size_transformation ) );
 		$breakpoints         = array();
-		while ( $max > $min ) {
+		while ( $max >= $min ) {
 			if ( $width >= $max ) {
 				$size_transformation['width']  = $max;
 				$size_transformation['height'] = floor( $max / $ratio );


### PR DESCRIPTION
Right now the following set up would not create the smallest image (440px).

![image](https://github.com/user-attachments/assets/fe5af317-5791-48bc-afbd-92a6d4d2d2ad)

This PR updates a condition that prevented the smallest image from being created.