### PR TITLE
Block patterns editor issue

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -202,6 +202,15 @@ class Delivery implements Setup {
 				'__return_true'
 			);
 
+			add_filter(
+				'cloudinary_prepare_size',
+				function ( $size ) {
+					unset( $size['transformation'] );
+					return $size;
+				}
+			);
+
+			// This is for patterns only, not for patterns in posts.
 			if ( false === strpos( $route, 'wp/v2/blocks/' ) ) {
 				add_filter(
 					'cloudinary_tag_skip_classes',

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -178,58 +178,7 @@ class Delivery implements Setup {
 				&& 'edit' === $request->get_param( 'context' )
 			)
 		) {
-			// This has a priority of 10 so can be overridden by other filters.
-			add_filter(
-				'cloudinary_unset_attributes',
-				'__return_true'
-			);
-
-			add_filter(
-				'cloudinary_apply_breakpoints',
-				'__return_false'
-			);
-
-			add_filter(
-				'cloudinary_parse_element',
-				static function ( $tag_element ) {
-					$tag_element['breakpoints'] = false;
-					return $tag_element;
-				}
-			);
-
-			add_filter(
-				'cloudinary_skip_responsive_breakpoints',
-				'__return_true'
-			);
-
-			add_filter(
-				'cloudinary_prepare_size',
-				function ( $size ) {
-					unset( $size['transformation'] );
-					return $size;
-				}
-			);
-
-			// This is for patterns only, not for patterns in posts.
-			if ( false === strpos( $route, 'wp/v2/blocks/' ) ) {
-				add_filter(
-					'cloudinary_tag_skip_classes',
-					function ( $skip, $tag_element ) {
-						// Bail on additional assets.
-						return $this->plugin->get_component( 'assets' )->is_asset( $tag_element['atts']['src'] );
-					},
-					10,
-					2
-				);
-
-				add_filter(
-					'cloudinary_parse_element',
-					function ( $element ) {
-						unset( $element['atts']['class'] );
-						return $element;
-					}
-				);
-			}
+			add_filter( 'cloudinary_skip_parse_element', '__return_true' );
 		}
 	}
 
@@ -1449,6 +1398,11 @@ class Delivery implements Setup {
 	 * @return array|null
 	 */
 	public function parse_element( $element ) {
+
+		if ( apply_filters( 'cloudinary_skip_parse_element', false, $element ) ) {
+			return null;
+		}
+
 		static $post_context = 0;
 
 		$config = $this->plugin->settings->get_value( 'image_settings' );


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->

This ~~tweaks what is included in the `img` tags on delivery~~ skips completely the filters and transforms on the original tag so the post and pattern editors and pattern list page don't have block editor validation errors.

This is a proof of concept and needs thorough testing.
