### PR TITLE
Experimental support for GLB models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ coverage/html/
 # ENV files
 .env
 
+# wp-env
+.wp-env.json
+
 # IDE
 .vscode
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudinary",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudinary",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "hasInstallScript": true,
       "license": "GPL-2.0+",
       "devDependencies": {

--- a/php/media/class-gallery.php
+++ b/php/media/class-gallery.php
@@ -30,6 +30,15 @@ class Gallery extends Settings_Component {
 	const GALLERY_LIBRARY_HANDLE = 'cld-gallery';
 
 	/**
+	 * This is a "false" mime type for GLB files.
+	 *
+	 * Canonically, the correct mime type for GLB files is `model/gltf-binary`,
+	 * however we need to fake an `image/` mime type to make the gallery
+	 * picker to list GLB files.
+	 */
+	const GALLERY_GLB_MIME_TYPE = 'image/glb';
+
+	/**
 	 * Holds the settings slug.
 	 *
 	 * @var string
@@ -462,6 +471,12 @@ class Gallery extends Settings_Component {
 			if ( ! wp_get_attachment_url( $attachment['attachmentId'] ) ) {
 				continue;
 			}
+
+			// Initialize 3D model support.
+			if ( self::GALLERY_GLB_MIME_TYPE === get_post_mime_type( $attachment['attachmentId'] ) ) {
+				$attachment['mediaType'] = '3d';
+			}
+
 			$transformations = $this->media->get_transformations( $attachment['attachmentId'] );
 			if ( ! empty( $transformations ) ) {
 				$attachment['transformation'] = array( 'transformation' => $transformations );
@@ -569,6 +584,50 @@ class Gallery extends Settings_Component {
 	}
 
 	/**
+	 * Allow GLB files to be uploaded.
+	 *
+	 * @param array $mimes The mime types.
+	 *
+	 * @return array
+	 */
+	public function add_glb_mime( $mimes ) {
+		$mimes['glb'] = self::GALLERY_GLB_MIME_TYPE;
+
+		return $mimes;
+	}
+
+	/**
+	 * Pass the GLB file type check.
+	 *
+	 * @param array  $file_data The file data.
+	 * @param string $file      The file.
+	 * @param string $filename  The filename.
+	 *
+	 * @return array
+	 */
+	public function pass_glb_filetype_check( $file_data, $file, $filename ) {
+		if ( 'glb' === pathinfo( $filename, PATHINFO_EXTENSION ) ) {
+			$file_data['ext']  = 'glb';
+			$file_data['type'] = self::GALLERY_GLB_MIME_TYPE;
+		}
+
+		return $file_data;
+	}
+
+	/**
+	 * Allow GLB files to be uploaded to Cloudinary.
+	 *
+	 * @param array $types The allowed extensions.
+	 *
+	 * @return array
+	 */
+	public function allow_glb_for_cloudinary( $types ) {
+		$types[] = 'glb';
+
+		return $types;
+	}
+
+	/**
 	 * Setup hooks for the gallery.
 	 */
 	public function setup_hooks() {
@@ -578,5 +637,23 @@ class Gallery extends Settings_Component {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		add_filter( 'render_block', array( $this, 'prepare_block_render' ), 10, 2 );
 		add_filter( 'cloudinary_admin_pages', array( $this, 'register_settings' ) );
+
+		/**
+		 * Filter to allow GLB files to be uploaded.
+		 *
+		 * WARNING: This is an experimental hook. When enabled, the GLB files
+		 *          will become uploadable in the media library, but these files
+		 *          will render no preview. Also, the only place where GLB files
+		 *          can be used is in the Cloudinary Gallery block.
+		 *
+		 * @param bool $allow_glb_upload Whether to allow GLB files to be uploaded.
+		 *
+		 * @return bool
+		 */
+		if ( apply_filters( 'cloudinary_allow_glb_upload', false ) ) {
+			add_filter( 'upload_mimes', array( $this, 'add_glb_mime' ), 20, 1 );
+			add_filter( 'wp_check_filetype_and_ext', array( $this, 'pass_glb_filetype_check' ), 10, 3 );
+			add_filter( 'cloudinary_allowed_extensions', array( $this, 'allow_glb_for_cloudinary' ) );
+		}
 	}
 }


### PR DESCRIPTION
Must be enabled by hooking into a filter in code.

```php
add_filter( 'cloudinary_allow_glb_upload', '__return_true' );
```