### PR TITLE
Fix DivisionByZeroError in Responsive_Breakpoints

### DIFF
--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -782,6 +782,24 @@ class Utils {
 	}
 
 	/**
+	 * Remove a debug message.
+	 *
+	 * @param string $key  The key that holds the message.
+	 */
+	public static function remove_log( $key ) {
+		if ( ! get_plugin_instance()->get_component( 'report' )->enabled() || ! $key ) {
+			return;
+		}
+
+		$messages = get_option( Sync::META_KEYS['debug'], array() );
+
+		if ( isset( $messages[ $key ] ) ) {
+			unset( $messages[ $key ] );
+			update_option( Sync::META_KEYS['debug'], $messages, false );
+		}
+	}
+
+	/**
 	 * Get the debug messages.
 	 *
 	 * @return array

--- a/php/delivery/class-responsive-breakpoints.php
+++ b/php/delivery/class-responsive-breakpoints.php
@@ -127,12 +127,19 @@ class Responsive_Breakpoints extends Delivery_Feature {
 	 * @return array
 	 */
 	protected function apply_breakpoints( $tag_element ) {
+		$settings  = $this->settings->get_value( 'media_display' );
+		$max       = $settings['max_width'];
+		$min       = $settings['min_width'];
+		$width     = (int) $tag_element['width'];
+		$height    = (int) $tag_element['height'];
+		$debug_key = 'responsive_breakpoints_' . $tag_element['id'];
 
-		$settings            = $this->settings->get_value( 'media_display' );
-		$max                 = $settings['max_width'];
-		$min                 = $settings['min_width'];
-		$width               = $tag_element['width'];
-		$height              = $tag_element['height'];
+		if ( ! $width || ! $height ) {
+			// Translators: %s is the ID of the image missing width or height.
+			Utils::log( sprintf( __( 'Missing width or height for image: %s', 'cloudinary' ), $tag_element['id'] ), $debug_key );
+			return $tag_element;
+		}
+
 		$size_tag            = '-' . $width . 'x' . $height . '.';
 		$step                = $settings['pixel_step'];
 		$ratio               = $width / $height;
@@ -158,6 +165,8 @@ class Responsive_Breakpoints extends Delivery_Feature {
 			$tag_element['atts']['srcset'] = implode( ', ', $breakpoints );
 			$tag_element['atts']['sizes']  = '(max-width: ' . $width . 'px) 100vw, ' . $width . 'px';
 		}
+
+		Utils::remove_log( $debug_key );
 
 		return $tag_element;
 	}


### PR DESCRIPTION
Fixing `DivisionByZeroError` occurring in the `Responsive_Breakpoints` class.

## Approach

 - If an attachment doesn't have `width` or `height`, the initial image tag will be rendered on the front-end without any srcset information.
 - Add a debug log if there is an issue with `width` and `height`.
 - Remove a debug log during syncing attachments.


## QA notes

 - Upload an image.
 - Set its height or width to `0` (during the tests a database update was followed)
 - Insert the image to a page.
 - Save and preview the page.
 - The image should appear without errors.
