### PR TITLE
Improve the update asset parent paths functionality for better performance

### DIFF
--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -10,6 +10,7 @@ namespace Cloudinary;
 use Cloudinary\Assets\Rest_Assets;
 use Cloudinary\Connect\Api;
 use Cloudinary\Sync;
+use Cloudinary\Cron;
 use Cloudinary\Traits\Params_Trait;
 use Cloudinary\Utils;
 use WP_Error;
@@ -388,27 +389,75 @@ class Assets extends Settings_Component {
 	}
 
 	/**
-	 * Register an asset path.
+	 * Update asset paths.
 	 *
-	 * @param string $path    The path/URL to register.
-	 * @param string $version The version.
+	 * @return void
 	 */
-	public static function register_asset_path( $path, $version ) {
-		$assets = self::$instance;
-		if ( $assets && ! $assets->is_locked() ) {
-			$asset_path = $assets->get_asset_parent( $path );
-			if ( null === $asset_path ) {
-				$asset_parent_id = $assets->create_asset_parent( $path, $version );
-				if ( is_wp_error( $asset_parent_id ) ) {
-					return; // Bail.
+	public function update_asset_paths() {
+		$assets = $this->settings->get_setting( 'assets' )->get_settings();
+
+		if ( empty( $assets ) || ! $this->is_locked() ) {
+			return;
+		}
+
+		foreach ( $assets as $asset ) {
+			$paths = $asset->get_setting( 'paths' );
+			foreach ( $paths->get_settings() as $path ) {
+				if ( 'on' === $path->get_value() ) {
+					$conf    = $path->get_params();
+					$path    = urldecode( trailingslashit( $conf['url'] ) );
+					$version = $conf['version'];
+
+					$asset_path = $this->get_asset_parent( $path );
+
+					if ( null === $asset_path ) {
+						$asset_parent_id = $assets->create_asset_parent( $path, $version );
+						if ( is_wp_error( $asset_parent_id ) ) {
+							return; // Bail.
+						}
+						$asset_path = get_post( $asset_parent_id );
+					}
+
+					// Check and update version if needed.
+					if ( $this->media->get_post_meta( $asset_path->ID, Sync::META_KEYS['version'], true ) !== $version ) {
+						$this->media->update_post_meta( $asset_path->ID, Sync::META_KEYS['version'], $version );
+					}
 				}
-				$asset_path = get_post( $asset_parent_id );
 			}
-			// Check and update version if needed.
-			if ( $assets->media->get_post_meta( $asset_path->ID, Sync::META_KEYS['version'], true ) !== $version ) {
-				$assets->media->update_post_meta( $asset_path->ID, Sync::META_KEYS['version'], $version );
+		}
+	}
+
+	/**
+	 * Activate parent assets based on the current settings and purges unused parent assets.
+	 *
+	 * @return void
+	 */
+	protected function activate_parents() {
+		$assets = $this->settings->get_setting( 'assets' )->get_settings();
+
+		if ( empty( $assets ) || $this->is_locked() ) {
+			return;
+		}
+
+		foreach ( $assets as $asset ) {
+			$paths = $asset->get_setting( 'paths' );
+
+			foreach ( $paths->get_settings() as $path ) {
+				if ( 'on' === $path->get_value() ) {
+					$conf = $path->get_params();
+					self::activate_parent( urldecode( trailingslashit( $conf['url'] ) ) );
+				}
 			}
-			$assets->activate_parent( $path );
+		}
+
+		// Get the disabled items.
+		foreach ( $this->asset_parents as $url => $parent ) {
+			if ( isset( $this->active_parents[ $url ] ) ) {
+				continue;
+			}
+			$this->purge_parent( $parent->ID );
+			// Remove parent.
+			wp_delete_post( $parent->ID );
 		}
 	}
 
@@ -1155,30 +1204,8 @@ class Assets extends Settings_Component {
 	 * @hook cloudinary_init_settings
 	 */
 	public function setup() {
-
-		$assets = $this->settings->get_setting( 'assets' )->get_settings();
-		$full   = 'on' === $this->settings->get_value( 'cache.enable' );
-		foreach ( $assets as $asset ) {
-
-			$paths = $asset->get_setting( 'paths' );
-
-			foreach ( $paths->get_settings() as $path ) {
-				if ( 'on' === $path->get_value() ) {
-					$conf = $path->get_params();
-					self::register_asset_path( urldecode( trailingslashit( $conf['url'] ) ), $conf['version'] );
-				}
-			}
-		}
-
-		// Get the disabled items.
-		foreach ( $this->asset_parents as $url => $parent ) {
-			if ( isset( $this->active_parents[ $url ] ) ) {
-				continue;
-			}
-			$this->purge_parent( $parent->ID );
-			// Remove parent.
-			wp_delete_post( $parent->ID );
-		}
+		$this->activate_parents();
+		Cron::register_process( 'update_asset_paths', array( $this, 'update_asset_paths' ), 60 );
 	}
 
 	/**


### PR DESCRIPTION
Improving the update asset paths functionality to deliver better performance on the front-end and when performing WP Rest API requests.

## Approach

 - The update and activate asset paths logic was split into two separate methods.
 - The process of updating the asset parent paths happens in these cases:
   - In the WordPress dashboard and the request is not REST API.
   - Using a cron (once a day). This covers manually uploaded plugins/themes.
 - The update process happens before the active one to ensure the activated asset parents are up to date.


## QA notes
- Ensure you have the WP Query Monitor plugin installed. 
- Ensure the `Enable additional asset syncing` setting is enabled and there are some plugins/themes activated. (screenshot attached below)
- Go to the WordPress dashboard, and in the WP Query Monitor, filter by `Plugin: cloudinary_wordpress` and `Caller: update_meta_cache()`. (screenshot attached below)
- While you're on the dashboard, there should be `update_meta_cache` queries that come from `Cloudinary\Assets->update_asset_paths()` as shown in the screenshot below. 
- Go to the Front-end, `update_meta_cache` from `Cloudinary\Assets->update_asset_paths()` shouldn't appear.
- Testing `Utils::is_rest_api()` can happen by using a REST API request as this one `wp-json/wp/v2/posts/?_envelope&_wpnonce=<nonce>` -- the nonce can be got from `wp-admin/admin-ajax.php?action=rest-nonce` -- more info [here](https://querymonitor.com/wordpress-debugging/rest-api-requests/).

**Enabled asset syncing**
<img width="600" alt="asset-syncing" src="https://github.com/user-attachments/assets/6a81ba7e-ffd5-4961-81a5-ef468b4ee797" />

**Postmeta queries**
![postmeta-queries-update](https://github.com/user-attachments/assets/5eab79f0-e5f7-4518-8e07-a8b642f9c925)




