### PR TITLE
Change the version of the video player to 2.3.5

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -587,7 +587,7 @@ final class Plugin {
 		 * The Cloudinary Video Player version.
 		 */
 		if ( ! defined( 'CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION' ) ) {
-			define( 'CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION', '2.2.0' );
+			define( 'CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION', '2.3.5' );
 		}
 	}
 


### PR DESCRIPTION
Changed the version of the video player.

## QA notes

- Ensure the new Cloudinary player renders correctly on the front-end.
- Ensure there are no console warnings from the player.
