### PR TITLE
Ensure single and double quotes are properly used when buiding img tags.

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1376,6 +1376,12 @@ class Delivery implements Setup {
 		// Setup new tag.
 		$replace = HTML::build_tag( $tag_element['tag'], $tag_element['atts'] );
 
+		// If the original tag used single quotes, we need to use them in the new tag.
+		$single_quotes = (bool) preg_match( '/=\s*\'/', $tag_element['original'] );
+		if ( $single_quotes ) {
+			$replace = str_replace( '"', "'", $replace );
+		}
+
 		/**
 		 * Filter the new built tag element.
 		 *


### PR DESCRIPTION
Some Page Builders use HTML markup inside JSON, which causes issues with single/double quotes when building our img tag.

## Approach

- Depending on the provided HTML tag, we use single or double quotes for our HTML element.


## QA notes

- Force the HTML tag to include single quotes (you can mock this locally).
- Do the same for double quotes to ensure it works.
