### PR TITLE
Ensure the storage is setup when using the size_sync outside of the class

### DIFF
--- a/php/sync/class-storage.php
+++ b/php/sync/class-storage.php
@@ -389,6 +389,10 @@ class Storage implements Notice {
 	 * @param string $public_id     Optional public ID.
 	 */
 	public function size_sync( $attachment_id, $public_id = null ) {
+		if ( empty( $this->media ) ) {
+			$this->setup();
+		}
+
 		if ( is_null( $public_id ) ) {
 			$public_id = $this->media->get_public_id( $attachment_id );
 		}


### PR DESCRIPTION
The `size_sync` method of the storage component is used by other components. For example, when preparing a report, the report might use the `size_sync` method, which uses other components.  If the storage isn't `setup`, this leads to a PHP fatal error. 

## Approach

- Init the setup if `$this->media` is missing

## QA notes

Two options:
- Use `$this->plugin->get_component( 'storage' )->size_sync( $media_id );`  outside of the Storage component.
- Find an attachment without `local_size` or `remote_size`, and generate a report. Previously, it caused errors.
