### PR TITLE
Fix _load_textdomain_just_in_time notice

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -158,6 +158,19 @@ class Media extends Settings_Component implements Setup {
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
 
+		// Add set cloudinary filters to init so i18n methods are usable.
+		add_action( 'init' , array( $this, 'set_cloudinary_filters' ) );
+
+		// Add upgrade hook, since setup methods are called after the connect upgrade has run.
+		add_action( 'cloudinary_version_upgrade', array( $this, 'upgrade_media_settings' ) );
+	}
+
+	/**
+	 * Media constructor.
+	 *
+	 * @param Plugin $plugin The global plugin instance.
+	 */
+	public function set_cloudinary_filters() {
 		/**
 		 * Filter the Cloudinary Media Library filters.
 		 *
@@ -173,9 +186,6 @@ class Media extends Settings_Component implements Setup {
 				SYNC::META_KEYS['unsynced']   => __( 'Unsynced', 'cloudinary' ),
 			)
 		);
-
-		// Add upgrade hook, since setup methods are called after the connect upgrade has run.
-		add_action( 'cloudinary_version_upgrade', array( $this, 'upgrade_media_settings' ) );
 	}
 
 	/**


### PR DESCRIPTION
Adds set_cloudinary_filters to the init hook.

Fixes #1038


## Approach

- The i18n function `__()` was being called in the constructor of the class which is considered to early
- I have moved the relevant code to a separate function and added the function as an action to take place on init.


## QA notes

- Detail the steps needed to verify the PR.
