### PR TITLE
Correct _load_textdomain_just_in_time PHP warnings

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -157,6 +157,7 @@ class Media extends Settings_Component implements Setup {
 	 */
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
+
 		add_action( 'init', array( $this, 'init_hook' ) );
 
 		// Add upgrade hook, since setup methods are called after the connect upgrade has run.

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -158,6 +158,9 @@ class Media extends Settings_Component implements Setup {
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
 		add_action( 'init', array( $this, 'init_hook' ) );
+
+		// Add upgrade hook, since setup methods are called after the connect upgrade has run.
+		add_action( 'cloudinary_version_upgrade', array( $this, 'upgrade_media_settings' ) );
 	}
 
 	/**
@@ -181,9 +184,6 @@ class Media extends Settings_Component implements Setup {
 				SYNC::META_KEYS['unsynced']   => __( 'Unsynced', 'cloudinary' ),
 			)
 		);
-
-		// Add upgrade hook, since setup methods are called after the connect upgrade has run.
-		add_action( 'cloudinary_version_upgrade', array( $this, 'upgrade_media_settings' ) );
 	}
 
 	/**

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -157,7 +157,15 @@ class Media extends Settings_Component implements Setup {
 	 */
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
+		add_action( 'init', array( $this, 'init_hook' ) );
+	}
 
+	/**
+	 * Initialize WordPress hooks for the Cloudinary media integration.
+	 *
+	 * @return void
+	 */
+	public function init_hook() {
 		/**
 		 * Filter the Cloudinary Media Library filters.
 		 *

--- a/php/class-meta-box.php
+++ b/php/class-meta-box.php
@@ -42,9 +42,7 @@ class Meta_Box {
 	}
 
 	/**
-	 * Initializes hooks for the meta box.
-	 *
-	 * Hooks into WordPress to add meta boxes and registers necessary handlers.
+	 * Initialize hooks for the meta box.
 	 *
 	 * @return void
 	 */

--- a/php/class-meta-box.php
+++ b/php/class-meta-box.php
@@ -35,6 +35,17 @@ class Meta_Box {
 	 */
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
+		add_action( 'init', array( $this, 'init_hook' ) );
+	}
+
+	/**
+	 * Initializes hooks for the meta box.
+	 *
+	 * Hooks into WordPress to add meta boxes and registers necessary handlers.
+	 *
+	 * @return void
+	 */
+	public function init_hook() {
 		add_action( 'add_meta_boxes', array( $this, 'register_meta_box' ) );
 		$this->register_handlers();
 	}

--- a/php/class-meta-box.php
+++ b/php/class-meta-box.php
@@ -35,7 +35,10 @@ class Meta_Box {
 	 */
 	public function __construct( Plugin $plugin ) {
 		$this->plugin = $plugin;
+
 		add_action( 'init', array( $this, 'init_hook' ) );
+
+		$this->register_handlers();
 	}
 
 	/**
@@ -47,7 +50,6 @@ class Meta_Box {
 	 */
 	public function init_hook() {
 		add_action( 'add_meta_boxes', array( $this, 'register_meta_box' ) );
-		$this->register_handlers();
 	}
 
 	/**


### PR DESCRIPTION
## Approach

- Prepared `init` method for `class-media.php` and `class-meta-box.php`.
- Execute the i18n functions inside the new init methods.

## QA notes

- Ensure there are no PHP warnings.
