### PR TITLE
Move register_handlers to init  in class-meta-box.php

### DIFF
--- a/php/class-meta-box.php
+++ b/php/class-meta-box.php
@@ -37,8 +37,6 @@ class Meta_Box {
 		$this->plugin = $plugin;
 
 		add_action( 'init', array( $this, 'init_hook' ) );
-
-		$this->register_handlers();
 	}
 
 	/**
@@ -48,6 +46,8 @@ class Meta_Box {
 	 */
 	public function init_hook() {
 		add_action( 'add_meta_boxes', array( $this, 'register_meta_box' ) );
+
+		$this->register_handlers();
 	}
 
 	/**


### PR DESCRIPTION
Optimize the execution of `register_handlers` in `class-meta-box.php` for meta hooks loading consistency.