### PR TITLE
Optimize wp_image_matches_ratio in get_crop

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -865,8 +865,8 @@ class Media extends Settings_Component implements Setup {
 					$cropped = ! wp_image_matches_ratio(
 					// PDFs do not always have width and height, but they do have full sizes.
 					// This is important for the thumbnail crops on the media library.
-						! empty( $meta['width'] ) ? $meta['width'] : $meta['sizes']['full']['width'],
-						! empty( $meta['height'] ) ? $meta['height'] : $meta['sizes']['full']['height'],
+						! empty( $meta['width'] ) ? $meta['width'] : ( ! empty( $meta['sizes']['full']['width'] ) ? $meta['sizes']['full']['width'] : 0 ),
+						! empty( $meta['height'] ) ? $meta['height'] : ( ! empty( $meta['sizes']['full']['height'] ) ? $meta['sizes']['full']['height'] : 0 ),
 						$size['width'],
 						$size['height']
 					);


### PR DESCRIPTION
Fixes https://github.com/cloudinary/cloudinary_wordpress/issues/941

## Approach

- Avoid warnings when with and height are missing (both main and full sizes).

## QA notes

- Insert an attachment without width or height
- There shouldn't be errors.
