### PR TITLE
Add `__isset()` method to `Relationship` class

### DIFF
--- a/php/relate/class-relationship.php
+++ b/php/relate/class-relationship.php
@@ -118,6 +118,19 @@ class Relationship {
 	}
 
 	/**
+	 * Check the existence of a relationship data value.
+	 *
+	 * @param string $key The key.
+	 *
+	 * @return bool
+	 */
+	public function __isset( $key ) {
+		$data_cache = $this->get_data();
+
+		return isset( $data_cache[ $key ] );
+	}
+
+	/**
 	 * Set the save on shutdown flag.
 	 */
 	public function save() {


### PR DESCRIPTION
Fixes #1049

## Approach

This adds a magic [`__isset()`](https://www.php.net/manual/en/language.oop5.overloading.php#object.isset) method to the `Cloudinary\Relate\Relationship` class to complement the existing `__get()` and `__set()` methods.

Without this, calling `isset()` on an overloaded property like `public_id` returns `false`, even when it is in fact set.

## QA notes

Following the reproduction steps in the linked issue, calling `isset()` on an overloaded property of a `Relationship` instance should now return `true` if it has a value in the `$data_cache`.