### PR TITLE
Set default cron tasks

### DIFF
--- a/php/class-cron.php
+++ b/php/class-cron.php
@@ -121,7 +121,11 @@ class Cron {
 					array(
 						'type'    => 'cron',
 						'slug'    => 'tasks',
-						'default' => array(),
+						'default' => array(
+							'update_asset_paths' => 'on',
+							'rest_api'           => 'on',
+							'check_status'       => 'on',
+						),
 						'cron'    => $this,
 					),
 				),


### PR DESCRIPTION
Ensuring the cron jobs are enabled by default.

## Approach

- Adding the name of the cron jobs to the default tasks array.

## QA notes

1. Firstly, add this filter to your local instance (usually this is done as a mu-plugin):
```
/**
 * Enables Cloudinary Cron Manager.
 * @see http://site.local/wp-admin/admin.php?page=cloudinary&section=cron_system
 */
add_filter( 'cloudinary_feature_cron_manager', '__return_true' );
```
2. After that, go to `wp-admin/admin.php?page=cloudinary&section=cron_system` .
3. Wait for the next run.
4. The last run column should indicate when the last run was. Previously, it said `waiting for`.