### PR TITLE
Optimize innerBlocks loop

### DIFF
--- a/php/media/class-video.php
+++ b/php/media/class-video.php
@@ -242,9 +242,12 @@ class Video {
 		if ( 'core/video' === $source_block['blockName'] ) {
 			return true;
 		}
-		foreach ( $source_block['innerBlocks'] as $block ) {
-			if ( $this->has_video_block( $block ) ) {
-				return true;
+
+		if ( ! empty( $source_block['innerBlocks'] ) ) {
+			foreach ( $source_block['innerBlocks'] as $block ) {
+				if ( $this->has_video_block( $block ) ) {
+					return true;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes:
```
PHP Warning:  Undefined array key "innerBlocks" in /wp-content/plugins/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php on line 245
PHP Warning:  foreach() argument must be of type array|object, null given in /wp-content/plugins/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/media/class-video.php on line 245
```

## Approach

- Ensure only blocks with `innerBlocks` are looped.


## QA notes

- Insert a Video inside a block that supports innerBlocks (e.g. columns).
- Go to the Editor and the front-end page.
- The PHP Warnings shouldn't appear in the debug.log.
