### PR TITLE
Fix cron-run.txt PHP warning

### DIFF
--- a/php/cron/class-lock-file.php
+++ b/php/cron/class-lock-file.php
@@ -33,7 +33,13 @@ class Lock_File {
 	 */
 	public function get_lock_file( $file = null ) {
 		$lock_file = $this->get_lock_file_name( $file );
-		$data      = file_get_contents( $lock_file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
+		if ( ! file_exists( $lock_file ) ) {
+			return '';
+		}
+
+		$data = file_get_contents( $lock_file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
 		if ( false !== strpos( $data, '[' ) ) {
 			$data = json_decode( $data, true );
 		}
@@ -106,5 +112,4 @@ class Lock_File {
 		$file = $this->get_lock_file_name( $file );
 		wp_delete_file( $file );
 	}
-
 }


### PR DESCRIPTION
Fixes this PHP warning:
```
PHP Warning:  file_get_contents(/Users/aatanasov/Local Sites/cloudinary/app/public/wp-content/uploads/cron/cron-run.txt): Failed to open stream: No such file or directory in /Users/aatanasov/Local Sites/cloudinary/app/public/wp-content/plugins/cloudinary_wordpress/php/cron/class-lock-file.php on line 41
```

## Approach

- Ensure `file_get_contents` is used when the file exists.

## QA notes

- Ensure you have the debug mode of your WordPress instance enabled.
- Go to `/wp-admin/admin.php?page=cloudinary&section=cron_system`
- Enable the cron (all options).
- Wait for the first run.
- Check `debug.log`
- The warning shouldn't appear.
