### PR TITLE
Improve unknown URLs search

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -883,6 +883,7 @@ class Delivery implements Setup {
 		$dirs    = wp_get_upload_dir();
 		$baseurl = Utils::clean_url( $dirs['baseurl'] );
 		$search  = array();
+
 		foreach ( $this->unknown as $url ) {
 			$url      = ltrim( str_replace( $baseurl, '', $url ), '/' );
 			$search[] = $url;
@@ -900,6 +901,7 @@ class Delivery implements Setup {
 		$key       = md5( $sql );
 		$cached    = wp_cache_get( $key );
 		$auto_sync = $this->sync->is_auto_sync_enabled();
+
 		if ( false === $cached ) {
 			$cached  = array();
 			$results = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
@@ -917,12 +919,14 @@ class Delivery implements Setup {
 					 * @return {int}
 					 */
 					$post_id = apply_filters( 'cloudinary_contextualized_post_id', $result->post_id );
+
 					if ( ! $this->is_deliverable( $post_id ) ) {
 						continue;
 					}
 					// If we are here, it means that an attachment in the media library doesn't have a delivery for the url.
 					// Reset the signature for delivery and add to sync, to update it.
 					$this->create_delivery( $post_id );
+
 					if ( true === $auto_sync ) {
 						$this->sync->add_to_sync( $post_id );
 					}
@@ -1920,7 +1924,70 @@ class Delivery implements Setup {
 			$this->set_usability( $result, $auto_sync );
 		}
 		// Set unknowns.
-		$this->unknown = array_diff( $urls, array_keys( $this->known ) );
+		$this->unknown = $this->filter_unknown_urls( $urls );
+	}
+
+	/**
+	 * Filter URLs to determine which are truly unknown, considering image size variations.
+	 *
+	 * This method treats image size variations (e.g., example-300x224.png) as "known"
+	 * if their base image (e.g., example.png) exists in the known URLs, while still
+	 * catching genuinely unknown URLs.
+	 *
+	 * @param array $urls All URLs found in content.
+	 *
+	 * @return array Array of genuinely unknown URLs.
+	 */
+	protected function filter_unknown_urls( $urls ) {
+		$known_keys = array_keys( $this->known );
+
+		if ( empty( $known_keys ) ) {
+			return $urls;
+		}
+
+		$known_lookup = array_flip( $known_keys );
+		$potential_unknown = array_diff( $urls, $known_keys );
+
+		if ( empty( $potential_unknown ) ) {
+			return array();
+		}
+
+		$truly_unknown = array();
+
+		foreach ( $potential_unknown as $url ) {
+			// Check if this might be a sized variation of a known image.
+			$base_url = $this->maybe_unsize_url( $url );
+
+			// If base image is known, skip this variation.
+			if ( isset( $known_lookup[ $base_url ] ) ) {
+				continue;
+			}
+
+			// Check scaled version if base wasn't found and URL was actually "unsized".
+			if ( $base_url !== $url ) {
+				$scaled_url = Utils::make_scaled_url( $base_url );
+				if ( isset( $known_lookup[ $scaled_url ] ) ) {
+					continue; // Scaled version is known, skip this variation.
+				}
+			}
+
+			// This URL is genuinely unknown.
+			$truly_unknown[] = $url;
+		}
+
+		/**
+		 * Filter the list of truly unknown URLs after filtering out image size variations.
+		 *
+		 * @hook   cloudinary_filter_unknown_urls
+		 * @since  3.2.12
+		 *
+		 * @param array $truly_unknown The filtered list of unknown URLs.
+		 * @param array $urls          The original list of all URLs.
+		 * @param array $known_keys    The list of known URL keys.
+		 *
+		 * @return array The filtered list of unknown URLs.
+		 */
+		return apply_filters( 'cloudinary_filter_unknown_urls', $truly_unknown, $urls, $known_keys );
 	}
 
 	/**


### PR DESCRIPTION
The plugin has a feature where it detects if there are unknown URLs and tries to sync them if they exist in the database ([code reference](https://github.com/cloudinary/cloudinary_wordpress/blob/master/php/class-delivery.php#L1950-L1952)).  When there are unknown URLs there is [a postmeta query](https://github.com/cloudinary/cloudinary_wordpress/blob/master/php/class-delivery.php#L896).

The main issue was that attachment sizes are considered unknown, which is incorrect. Because of that, the postmeta query was executed on every page request. For large websites, this can be an issue.

## Approach

- Added a method to find truly unknown files.

## QA notes

- Install Query Monitor.
- Go to a page with attachments.
- This query shouldn't appear: <img width="1550" height="125" alt="postmeta-query" src="https://github.com/user-attachments/assets/0616177a-479f-479f-9f62-6917da792d43" />
 - Go to `wp-content/uploads/2025/07/` and add an image file (e.g. `testing-image-sync.jpg`). This should happen outside of WordPress.
 - After that, using the code editor, insert this image tag: `<img src="http://cloudinary.local/wp-content/uploads/2025/07/testing-image-sync.jpg" />` (set the correct src based on your instance) to a page.
 - Save the page.
 - Go to the page on the front-end to confirm the test image isn't delivered from Cloudinary.
 - Using PHP script, insert [the attachment](https://developer.wordpress.org/reference/functions/wp_insert_attachment/) (outside of WP Media Library). This is a script generated with Copilot: [insert-attachment.php.zip](https://github.com/user-attachments/files/21312400/insert-attachment.php.zip) -- open the admin page only once.
 - Go to the page again, and the `Cloudinary\Delivery->find_attachment_size_urls()` query should appear in Query Monitor.
 - Wait for a minute, and refresh the page. 
 - Finally, the previously unknown image should be delivered from Cloudinary, and the postmeta query shouldn't appear.

