### PR TITLE
Fix audio source tags

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1461,6 +1461,12 @@ class Delivery implements Setup {
 		// Break element up.
 		$attributes         = shortcode_parse_atts( $element );
 		$tag_element['tag'] = array_shift( $attributes );
+
+		// Skip audio source tags.
+		if ( ! empty( $attributes['type'] ) && 0 === strpos( $attributes['type'], 'audio/' ) && 'source' === $tag_element['tag'] ) {
+			return null;
+		}
+
 		// Context Switch Check.
 		if ( 'article' === $tag_element['tag'] ) {
 			if ( ! empty( $attributes['id'] ) && false !== strpos( $attributes['id'], 'post-' ) ) {


### PR DESCRIPTION
Fixes audio source tags.

## Approach

- Ensuring audio source tags aren't converted.

## QA notes

 - Go to a post and insert an audio file.
 - The audio file should work correctly on the front-end.
 - Install the classic editor.
 - Go to a new page and insert an audio file.
 - The audio file should work correctly on the front-end.
 - There shouldn't be any errors.
