### PR TITLE
Fix WP Ceber login page

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -719,7 +719,12 @@ final class Plugin {
 	 * Output script data if set.
 	 */
 	public function print_script_data() {
+		if ( ! isset( $this->settings ) || ! method_exists( $this->settings, 'get_param' ) ) {
+			return;
+		}
+
 		$handles = $this->settings->get_param( '@script' );
+
 		if ( ! empty( $handles ) ) {
 			foreach ( $handles as $handle => $data ) {
 				// We should never be using multiple handles. This is just for cases where data needs to be added where the main script is not loaded.


### PR DESCRIPTION
Ensure print_script_data doesn't throw errors when using https://wpcerber.com/how-to-rename-wp-login-php/

## Approach

 - Ensure `$handles = $this->settings->get_param( '@script' );` is executed only when settings are available.

## QA notes

- Install https://wpcerber.com/installation/
- Activate the hidden login page: https://wpcerber.com/how-to-rename-wp-login-php/
- Ensure this error doesn't appear:

<img width="1125" height="770" alt="wp-error" src="https://github.com/user-attachments/assets/a6a27a6b-099f-4067-9e72-2096ceef64dc" />

