### PR TITLE
Fix the feature to disable additional assets

### DIFF
--- a/php/assets/class-rest-assets.php
+++ b/php/assets/class-rest-assets.php
@@ -258,8 +258,8 @@ class Rest_Assets {
 		$state = $request['state'];
 		foreach ( $ids as $id ) {
 			$where = array(
-				'post_id'    => $id,
-				'post_state' => 'asset',
+				'post_id'   => $id,
+				'sync_type' => 'asset',
 			);
 			if ( 'delete' === $state ) {
 				$data = array(


### PR DESCRIPTION
Fix the feature to disable additional assets.

## Approach 

When clicking “Apply Changes”, the Cloudinary plugin calls the `disable_cache_items` REST API endpoint via AJAX. 

The implementation of this API endpoint had a typo where it was looking for the existing `asset` as a `post_state` instead of a `sync_type`, resulting in the UPDATE  SQL query not updating anything.

## QA Notes

- Install the following test image plugin  [test-image-updated(1).zip](https://github.com/user-attachments/files/21766013/test-image-updated.1.zip)
- Go to the Cloudinary General Settings page and make sure it’s configured to delivery assets from this plugin
- Go to the Test Image plugin page which should display two images. Wait a minute for the assets to load. Refresh and confirm the assets are now delivered from Cloudinary
- Go back to the Cloudinary General Settings, and untick (or uncheck) one of the two image URL within this plugin, and click “Apply Changes”
- Go back again to the Test Image plugin page and confirm the image URL you just unchecked is now delivered from WP. The other image should still be delivered from Cloudinary.

