### PR TITLE
Avoid Sync Types Fatal Errors

### DIFF
--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -372,10 +372,13 @@ class Sync implements Setup, Assets {
 				$signature = array();
 			}
 
-			// Remove any old or outdated signature items. against the expected.
-			$signature                    = array_intersect_key( $signature, $this->sync_types );
 			$signatures[ $attachment_id ] = $return;
-			$return                       = wp_parse_args( $signature, $this->sync_types );
+
+			// Remove any old or outdated signature items. against the expected.
+			if ( ! empty( $this->sync_types ) ) {
+				$signature = array_intersect_key( $signature, $this->sync_types );
+				$return    = wp_parse_args( $signature, $this->sync_types );
+			}
 		}
 
 		/**
@@ -789,9 +792,12 @@ class Sync implements Setup, Assets {
 
 		$return      = array();
 		$asset_state = $this->get_asset_state( $attachment_id );
-		foreach ( array_keys( $this->sync_types ) as $type ) {
-			if ( $asset_state >= $this->sync_base_struct[ $type ]['asset_state'] ) {
-				$return[ $type ] = $this->generate_type_signature( $type, $attachment_id );
+
+		if ( ! empty( $this->sync_types ) ) {
+			foreach ( array_keys( $this->sync_types ) as $type ) {
+				if ( $asset_state >= $this->sync_base_struct[ $type ]['asset_state'] ) {
+					$return[ $type ] = $this->generate_type_signature( $type, $attachment_id );
+				}
 			}
 		}
 
@@ -844,7 +850,7 @@ class Sync implements Setup, Assets {
 		$required_signature   = $this->generate_signature( $attachment_id, $cached );
 		$attachment_signature = $this->get_signature( $attachment_id, $cached );
 		$attachment_signature = array_intersect_key( $attachment_signature, $required_signature );
-		if ( is_array( $required_signature ) ) {
+		if ( is_array( $required_signature ) && ! empty( $this->sync_types ) ) {
 			$sync_items = array_filter(
 				$attachment_signature,
 				function ( $item, $key ) use ( $required_signature ) {
@@ -1108,8 +1114,8 @@ class Sync implements Setup, Assets {
 		wp_redirect(
 			add_query_arg(
 				array(
-					'page'    => 'cloudinary',
-					'action'  => 'cleaned_up',
+					'page'   => 'cloudinary',
+					'action' => 'cleaned_up',
 				),
 				admin_url( 'admin.php' )
 			)

--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -51,7 +51,7 @@ class Sync implements Setup, Assets {
 	 *
 	 * @var array
 	 */
-	protected $sync_types;
+	protected $sync_types = array();
 
 	/**
 	 * Holds a list of unsynced images to push on end.


### PR DESCRIPTION
This ensures that even if the sync types aren't loaded, there's no fatal errors due to sync_types being null.

## Approach

Main reason: Current fatal errors occurs because the `sync_types` property is set to null (instead of an array). By default, properties in PHP are initialized as null unless told otherwise. By initializing it to an empty array, we can guarantee these fatal errors won't occur.

More detailed investigation of the reported issue:
- This `sync_types` property is assigned only in one place, which is the `setup_sync_types` method, which comes originally from this `init` filter with a priority of **200** https://github.com/cloudinary/cloudinary_wordpress/blob/master/php/class-plugin.php#L278 
- The reported broken site is using another plugin called [Rank Math SEO](https://wordpress.org/plugins/seo-by-rank-math/) which initialize its settings page on an `init` filter of priority **125**. This means this executes before `sync_types`
- That plugin calls `wp_get_attachment_image_src` within its settings page, which in turns calls our own cloudinary filter, resulting in the sync_types variable being called before it is initialized.
- The needs for this plugin to call this this early is simply to build a preview of the google search results. It supports a way to add a link to the featured image, which when added causes that issue.

Here's a stack trace of the issue (using XDebug)
![Screenshot 2025-08-22 at 10 07 00](https://github.com/user-attachments/assets/333371bd-1b14-46d5-802d-dfc7fb22b6c6)


## QA notes

Two approaches:

1. Import the backup of the site having the issue (a bit long as the site is quite large)
2. Follow the manual steps below to reproduce it:

- Install and activate the `Rank Math SEO` plugin
- Configure it using its Wizard
  - create a free account
  - set the installer to "easy" mode and leave the other values as default
- Create a new post
  - add a post title and a featured image to it 
- On the editor, there should be a new button for the Rank Math SEO in the top right, click on it
  - Then click on "Edit Snippet"
![Screenshot 2025-08-22 at 11 08 13](https://github.com/user-attachments/assets/6ca24143-ef79-49e5-9f0c-442e1dc47cfb)
  - Within the post description field, input the `%post_thumbnail%` variable
  - Save the changes for the snippet and publish the post
- Without the current fix, the site should now crash
- With the fix, the site should work & the snippet preview should show the cloudinary link properly 
