### PR TITLE
Avoid SVG conversion for pulled SVG from Cloudinary if SVG support is enabled

### DIFF
--- a/php/class-svg.php
+++ b/php/class-svg.php
@@ -218,6 +218,21 @@ class SVG extends Delivery_Feature {
 	}
 
 	/**
+	 * Disable SVG conversion.
+	 *
+	 * @param array $base_types The base types for conversion.
+	 *
+	 * @return array
+	 */
+	public function disable_svg_conversion( $base_types ) {
+		if ( $this->is_active() && ! empty( $base_types['svg'] ) ) {
+			unset( $base_types['svg'] );
+		}
+
+		return $base_types;
+	}
+
+	/**
 	 * Setup the component
 	 */
 	public function setup_hooks() {
@@ -233,6 +248,7 @@ class SVG extends Delivery_Feature {
 		add_filter( 'cloudinary_allowed_extensions', array( $this, 'allow_svg_for_cloudinary' ) );
 		add_filter( 'cloudinary_upload_options', array( $this, 'remove_svg_eagers' ), 10, 2 );
 		add_filter( 'cloudinary_upload_args', array( $this, 'upload_args' ), 10, 2 );
+		add_filter( 'cloudinary_convert_media_types', array( $this, 'disable_svg_conversion' ) );
 
 		// Add actions.
 		add_action( 'cloudinary_uploaded_asset', array( $this, 'maybe_setup_metadata' ), 10, 2 );

--- a/php/class-svg.php
+++ b/php/class-svg.php
@@ -219,6 +219,7 @@ class SVG extends Delivery_Feature {
 
 	/**
 	 * Disable SVG conversion.
+	 * If SVG support is active, we don't want to convert SVGs to other formats.
 	 *
 	 * @param array $base_types The base types for conversion.
 	 *


### PR DESCRIPTION
When we pull an SVG from Cloudinary, if SVG support is enabled we should expect it to be disabled as an SVG file. 

However, it is currently displaying as a PNG.

## Approach

- If the setting is supported, disable SVG conversion using the `cloudinary_convert_media_types` filter

## QA notes

-  Go to Cloudinary Image Settings page
   - Make sure **SVG Support** toggle is enabled
- Create a new post/page
  - Add an image block
    - Import an SVG from Cloudinary (if none are present in your account, import one using Cloudinary DAM)
  - Make sure the SVG is displayed as an SVG on the editor
  - Publish and view the post 
    - Check that it displays as an SVG on the frontend too and that it has expected SVG transformations (e.g. `f_svg,q_auto/fl_sanitize`)
- Go back to Cloudinary Image Settings page
   - Toggle OFF the **SVG Support** setting
- Follow the same previous step to add a new post with an uploaded SVG
  - It should be converted to a PNG
