### PR TITLE
Fix Tax Labels Warning

### DIFF
--- a/php/templates/taxonomy-transformation-fields.php
+++ b/php/templates/taxonomy-transformation-fields.php
@@ -13,8 +13,24 @@ wp_enqueue_script( 'cld-player' );
 
 wp_add_inline_script( 'cloudinary', 'var CLD_GLOBAL_TRANSFORMATIONS = CLD_GLOBAL_TRANSFORMATIONS ? CLD_GLOBAL_TRANSFORMATIONS : {};', 'before' );
 
-$tax_slug   = Utils::get_sanitized_text( 'taxonomy' );
-$tax_labels = get_taxonomy_labels( get_taxonomy( $tax_slug ) );
+$tax_slug = Utils::get_sanitized_text( 'taxonomy' );
+
+if ( empty( $tax_slug ) ) {
+	return;
+}
+
+$current_taxonomy = get_taxonomy( $tax_slug );
+
+if ( ! $current_taxonomy instanceof WP_Taxonomy ) {
+	return;
+}
+
+$tax_labels = get_taxonomy_labels( $current_taxonomy );
+
+if ( empty( $tax_labels ) ) {
+	return;
+}
+
 $cloudinary = get_plugin_instance();
 ?>
 <div class="cloudinary-collapsible">


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
Fixes https://wordpress.org/support/topic/attempt-to-assign-property-labels-on-false-in-taxonomy-integration/


## Approach
 - Ensuring `get_taxonomy` and `get_taxonomy_labels` are executed when the taxonomy is available.


## QA notes

 - Install the WooCommerce and Customer Reviews for WooCommerce
 - Go to `wp-admin/admin.php?page=cr-tags` and ensure the warning doesn't appear.
 - Go to `/wp-admin/edit-tags.php?taxonomy=category` and ensure the **Cloudinary Category transformations** panel appears.
