### PR TITLE
Optimizing the query_relations long query

### DIFF
--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -1009,7 +1009,7 @@ class Utils {
 	 * @return array
 	 */
 	public static function query_relations( $public_ids, $urls = array() ) {
-		$chunk_size = 50; // Number of items per chunk, configurable.
+		$chunk_size = 25;
 		$results    = array();
 		$tablename  = self::get_relationship_table();
 

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -1009,19 +1009,16 @@ class Utils {
 	 * @return array
 	 */
 	public static function query_relations( $public_ids, $urls = array() ) {
-		global $wpdb;
-
-		$wheres          = array();
-		$searched_things = array();
+		$chunk_size = 50; // Number of items per chunk, configurable.
+		$results    = array();
+		$tablename  = self::get_relationship_table();
 
 		/**
 		 * Filter the media context query.
 		 *
 		 * @hook   cloudinary_media_context_query
 		 * @since  3.2.0
-		 *
 		 * @param $media_context_query {string} The default media context query.
-		 *
 		 * @return {string}
 		 */
 		$media_context_query = apply_filters( 'cloudinary_media_context_query', 'media_context = %s' );
@@ -1031,43 +1028,60 @@ class Utils {
 		 *
 		 * @hook   cloudinary_media_context_things
 		 * @since  3.2.0
-		 *
 		 * @param $media_context_things {array} The default media context things.
-		 *
 		 * @return {array}
 		 */
 		$media_context_things = apply_filters( 'cloudinary_media_context_things', array( 'default' ) );
 
+		// Query for urls in chunks.
 		if ( ! empty( $urls ) ) {
-			// Do the URLS.
-			$list            = implode( ', ', array_fill( 0, count( $urls ), '%s' ) );
-			$where           = "(url_hash IN( {$list} ) AND {$media_context_query} )";
-			$searched_things = array_merge( $searched_things, array_map( 'md5', $urls ), $media_context_things );
-			$wheres[]        = $where;
+			$results = array_merge( $results, self::run_chunked_query( 'url_hash', $urls, $chunk_size, $tablename, $media_context_query, $media_context_things ) );
 		}
+		// Query for public_ids in chunks.
 		if ( ! empty( $public_ids ) ) {
-			// Do the public_ids.
-			$list            = implode( ', ', array_fill( 0, count( $public_ids ), '%s' ) );
-			$where           = "(public_hash IN( {$list} ) AND {$media_context_query} )";
-			$searched_things = array_merge( $searched_things, array_map( 'md5', $public_ids ), $media_context_things );
-			$wheres[]        = $where;
-		}
-
-		$results = array();
-
-		if ( ! empty( array_filter( $wheres ) ) ) {
-			$tablename = self::get_relationship_table();
-			$sql       = "SELECT * from {$tablename} WHERE " . implode( ' OR ', $wheres );
-			$prepared  = $wpdb->prepare( $sql, $searched_things ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$cache_key = md5( $prepared );
-			$results   = wp_cache_get( $cache_key, 'cld_delivery' );
-			if ( empty( $results ) ) {
-				$results = $wpdb->get_results( $prepared, ARRAY_A );// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery
-				wp_cache_add( $cache_key, $results, 'cld_delivery' );
-			}
+			$results = array_merge( $results, self::run_chunked_query( 'public_hash', $public_ids, $chunk_size, $tablename, $media_context_query, $media_context_things ) );
 		}
 
 		return $results;
+	}
+	/**
+	 * Run a chunked query and merge results.
+	 *
+	 * @param string $field The DB field to query (url_hash or public_hash).
+	 * @param array  $items The items to query.
+	 * @param int    $chunk_size Number of items per chunk.
+	 * @param string $tablename The table name.
+	 * @param string $media_context_query The media context SQL.
+	 * @param array  $media_context_things The media context values.
+	 * @return array
+	 */
+	protected static function run_chunked_query( $field, $items, $chunk_size, $tablename, $media_context_query, $media_context_things ) {
+		global $wpdb;
+
+		$all_results = array();
+		$chunks      = array_chunk( $items, $chunk_size );
+
+		foreach ( $chunks as $chunk ) {
+			$list            = implode( ', ', array_fill( 0, count( $chunk ), '%s' ) );
+			$where           = "({$field} IN( {$list} ) AND {$media_context_query} )";
+			$searched_things = array_merge( array_map( 'md5', $chunk ), $media_context_things );
+			$sql             = "SELECT * from {$tablename} WHERE {$where}";
+			$prepared        = $wpdb->prepare( $sql, $searched_things ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$cache_key       = md5( $prepared );
+			$chunk_results   = wp_cache_get( $cache_key, 'cld_delivery' );
+
+			if ( empty( $chunk_results ) ) {
+				$chunk_results = $wpdb->get_results( $prepared, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery
+
+				wp_cache_add( $cache_key, $chunk_results, 'cld_delivery' );
+			}
+
+			if ( ! empty( $chunk_results ) ) {
+				$all_results = array_merge( $all_results, $chunk_results );
+			}
+		}
+
+		return $all_results;
 	}
 
 	/**


### PR DESCRIPTION
Hosting platforms like WP Engine have the following SELECT query checks:
 - [Killed Query](https://wpengine.com/support/troubleshoot-wordpress-wp-engine-error-log/#killedquery):  _Query terminated because it is over 16,000 characters._
 - [Long Query](https://wpengine.com/support/troubleshoot-wordpress-wp-engine-error-log/#longquery): _Query noted because it is over 1,024 characters._

With this PR, we ensure the query_relations SELECT queries are lower than 1024 characters.

## Approach

- Splitting the `query_relations` query into chunks.
- Setting a chunk size of 25 relation hashes to ensure the length of each chunk SELECT query is lower than 1024 characters.

## QA notes

**Before checking out this branch:**

- Install [Query Monitor](https://wordpress.org/plugins/query-monitor/).
- Go to some pages and check the returned rows of this query in Query Monitor.

<img width="500" height="auto" alt="7b99086b-2f06-4c51-960f-086a212747cb" src="https://github.com/user-attachments/assets/1885318b-bc4a-4a2d-b418-62199a7dac5c" />

**After checking out this branch:**

 - Go to the same pages and sum the returned rows of all chunks. The number should match the previous number.
 - Grab a few chunks and check if the characters' length exceeds 1024 characters.
 - Ensure all Cloudinary delivered images on the front-end are delivered as it was before checking out this branch.

It is expected that the number of hashes be more than the actual images because we also check for sized URLs.

<img width="500" height="auto" alt="Screenshot 2025-09-26 at 15 48 42" src="https://github.com/user-attachments/assets/10291964-2ddb-4c42-ba84-5301175e701d" />
