### PR TITLE
Improve sanitize_slug

### DIFF
--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -117,6 +117,7 @@ class Assets extends Settings_Component {
 	 */
 	public function __construct( Plugin $plugin ) {
 		parent::__construct( $plugin );
+		$this->should_sanitize_slugs = true;
 
 		$this->media    = $plugin->get_component( 'media' );
 		$this->delivery = $plugin->get_component( 'delivery' );

--- a/php/traits/trait-params.php
+++ b/php/traits/trait-params.php
@@ -31,6 +31,13 @@ trait Params_Trait {
 	public $separator = '.';
 
 	/**
+	 * Whether to sanitize slugs.
+	 *
+	 * @var boolean
+	 */
+	protected $should_sanitize_slugs = false;
+
+	/**
 	 * Sets the params recursively.
 	 *
 	 * @param array $parts The parts to set.
@@ -77,7 +84,6 @@ trait Params_Trait {
 	 * @return $this
 	 */
 	public function set_param( $param, $value = null ) {
-
 		$sanitized_param = $this->sanitize_slug( $param );
 		$parts           = explode( $this->separator, $sanitized_param );
 		$param           = array_shift( $parts );
@@ -140,6 +146,9 @@ trait Params_Trait {
 	 * @return string
 	 */
 	protected function sanitize_slug( $slug ) {
+		if ( ! $this->should_sanitize_slugs || ! str_contains( $slug, $this->separator ) ) {
+			return $slug;
+		}
 
 		$sanitized = array_map( 'sanitize_file_name', explode( $this->separator, $slug ) );
 


### PR DESCRIPTION
Improve the `sanitize_slug` method for better performance.


## Approach

- `sanitize_slug` is used when needed only.


## QA notes

- Ensure images are delivered from Cloudinary and the admin settings work.
