### PR TITLE
Strip inline SVG data URIs prior to content parsing

### DIFF
--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -620,6 +620,9 @@ class Utils {
 	 * @return array
 	 */
 	public static function extract_urls( $content ) {
+		// Remove inline SVG data URIs, as they can cause parsing issues when extracting URLs.
+		$content = self::strip_inline_svg_data_uris( $content );
+
 		preg_match_all(
 			"#([\"']?)("
 				. '(?:[\w-]+:)?//?'
@@ -641,6 +644,25 @@ class Utils {
 
 		return array_values( $post_links );
 	}
+
+	/**
+	 * Strip inline SVG data URIs from content.
+	 *
+	 * @param string $content The content to process.
+	 *
+	 * @return string The content with SVG data URIs removed.
+	 */
+	public static function strip_inline_svg_data_uris( $content ) {
+		// Pattern to match the data URI structure: data:image/svg+xml;base64,<base64-encoded-data>.
+		$svg_data_uri_pattern = '/data:image\/svg\+xml;base64,[a-zA-Z0-9\/\+\=]+/i';
+
+		// Remove all occurrences of SVG data URIs from the content.
+		$cleaned_content = preg_replace( $svg_data_uri_pattern, '', $content );
+
+		// In case an error occurred, we return the original content to avoid data loss.
+		return is_null( $cleaned_content ) ? $content : $cleaned_content;
+	}
+
 
 	/**
 	 * Is saving metadata.


### PR DESCRIPTION
Inline SVG data can cause some issues to our parsing if they're too long. 
Given we're not interested in these, it's simpler to strip them out prior to our parsing.

<!-- Please reference the issue number this pull request addresses. -->
Fixes [#1092](https://github.com/cloudinary/cloudinary_wordpress/issues/1092)


## Approach

- The current parsing fails when encountering large inline SVG files within the page content
- By filtering these out prior to the parsing, we ensures the parsing won't have issues, and we don't risk breaking the existing parsing functionality.


## QA notes

- Install and activate this test plugin which adds some large inline SVGs to the content:
[inline-svg-test.zip](https://github.com/user-attachments/files/22790076/inline-svg-test.zip)
  - the original issue was related to the Jet Engine plugin. This can work too to reproduce it, but I've noticed that it doesn't always occur. the test plugin above reproduces the bug every time by generating even larger inline SVGs.
- Go to Cloudinary General Settings
  - Set storage to Cloudinary Only
  - Save Changes
- Go to Media library
  - You might need to wait a minute for the local assets to be removed
  - Click on "edit" for an existing image
  - Without the patch, the image preview doesn't show, while once patched the image is displayed.
