### PR TITLE
Fix edit asset admin page warning

### DIFF
--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -298,7 +298,7 @@ class Admin {
 			$page = $this->get_param( 'current_section' );
 		}
 
-		$this->set_param( 'active_slug', $page['slug'] );
+		$this->set_param( 'active_slug', isset( $page['slug'] ) ? $page['slug'] : '' );
 		$setting         = $this->init_components( $page, $screen->id );
 		$this->component = $setting->get_component();
 		$template        = $this->section;


### PR DESCRIPTION
Fixes `PHP Warning:  Undefined array key "slug" in php/class-admin.php on line 301`.

## Approach

- Ensure we use `$page['slug']` when avaialble.

## QA notes

- Go to edit the transformations of an asset and ensure there is no PHP Warning.
