### PR TITLE
Add support for background images within Elementor

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -14,6 +14,7 @@ use Cloudinary\Component\Setup;
 use Cloudinary\Delivery\Lazy_Load;
 use Cloudinary\Delivery\Responsive_Breakpoints;
 use Cloudinary\Assets as CLD_Assets;
+use Cloudinary\Integrations\Elementor;
 use Cloudinary\Integrations\WPML;
 use Cloudinary\Media\Gallery;
 use Cloudinary\Sync\Storage;
@@ -31,7 +32,7 @@ final class Plugin {
 	 *
 	 * @since   0.1
 	 *
-	 * @var     Admin|CLD_Assets|Connect|Dashboard|Deactivation|Delivery|Extensions|Gallery|Lazy_Load|Media|Meta_Box|Relate|Report|Responsive_Breakpoints|REST_API|State|Storage|SVG|Sync|URL[]|WPML|null
+	 * @var     Admin|CLD_Assets|Connect|Dashboard|Deactivation|Delivery|Extensions|Gallery|Lazy_Load|Media|Meta_Box|Relate|Report|Responsive_Breakpoints|REST_API|State|Storage|SVG|Sync|URL[]|WPML|Elementor|null
 	 */
 	public $components;
 	/**
@@ -136,6 +137,7 @@ final class Plugin {
 		$this->components['metabox']                = new Meta_Box( $this );
 		$this->components['url']                    = new URL( $this );
 		$this->components['wpml']                   = new WPML( $this );
+		$this->components['elementor']              = new Elementor( $this );
 		$this->components['special_offer']          = new Special_Offer( $this );
 	}
 

--- a/php/integrations/class-elementor.php
+++ b/php/integrations/class-elementor.php
@@ -22,27 +22,27 @@ class Elementor extends Integrations {
 	 * @var array
 	 */
 	const ELEMENTOR_BACKGROUND_IMAGES = array(
-		'_background_image'              => array(
+		'background_image'              => array(
 			'device' => 'desktop',
 			'suffix' => '',
 		),
-		'_background_hover_image'        => array(
+		'background_hover_image'        => array(
 			'device' => 'desktop',
 			'suffix' => ':hover',
 		),
-		'_background_image_tablet'       => array(
+		'background_image_tablet'       => array(
 			'device' => 'tablet',
 			'suffix' => '',
 		),
-		'_background_hover_image_tablet' => array(
+		'background_hover_image_tablet' => array(
 			'device' => 'tablet',
 			'suffix' => ':hover',
 		),
-		'_background_image_mobile'       => array(
+		'background_image_mobile'       => array(
 			'device' => 'mobile',
 			'suffix' => '',
 		),
-		'_background_hover_image_mobile' => array(
+		'background_hover_image_mobile' => array(
 			'device' => 'mobile',
 			'suffix' => ':hover',
 		),
@@ -84,13 +84,23 @@ class Elementor extends Integrations {
 		}
 
 		foreach ( self::ELEMENTOR_BACKGROUND_IMAGES as $background_key => $background_data ) {
-			// We need to have the ID from the image to proceed.
-			if ( ! isset( $settings[ $background_key ]['id'] ) ) {
+			$background = null;
+
+			if ( isset( $settings[ $background_key ] ) ) {
+				// Elementor section/column elements store background settings without a leading underscore.
+				$background = $settings[ $background_key ];
+			} elseif ( isset( $settings[ '_' . $background_key ] ) ) {
+				// Elementor basic elements (e.g. heading) store background settings with a leading underscore.
+				$background = $settings[ '_' . $background_key ];
+			}
+
+			// If this specific background setting is not set, we can skip it and check for the next setting.
+			if ( empty( $background ) || ! isset( $background['id'] ) ) {
 				continue;
 			}
 
-			$media_id   = $settings[ $background_key ]['id'];
-			$media_size = isset( $settings[ $background_key ]['size'] ) ? $settings[ $background_key ]['size'] : array();
+			$media_id   = $background['id'];
+			$media_size = isset( $background['size'] ) ? $background['size'] : array();
 
 			// Skip if the media is not deliverable via Cloudinary.
 			if ( ! $delivery->is_deliverable( $media_id ) ) {

--- a/php/integrations/class-elementor.php
+++ b/php/integrations/class-elementor.php
@@ -64,6 +64,7 @@ class Elementor extends Integrations {
 	 */
 	public function register_hooks() {
 		add_action( 'elementor/element/parse_css', array( $this, 'replace_bg_images_in_css' ), 10, 2 );
+		add_action( 'cloudinary_flush_cache', array( $this, 'clear_elementor_css_cache' ) );
 	}
 
 	/**
@@ -114,6 +115,19 @@ class Elementor extends Integrations {
 			}
 
 			$post_css->get_stylesheet()->add_rules( $css_selector, $css_rule, $media_query );
+		}
+	}
+
+	/**
+	 * Clear Elementor CSS cache.
+	 * This is called when Cloudinary cache is flushed, so that any change in media URLs is reflected in Elementor CSS files.
+	 *
+	 * @return void
+	 */
+	public function clear_elementor_css_cache() {
+		if ( class_exists( 'Elementor\Plugin' ) ) {
+			$elementor = Plugin::instance();
+			$elementor->files_manager->clear_cache();
 		}
 	}
 }

--- a/php/integrations/class-elementor.php
+++ b/php/integrations/class-elementor.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Elementor integration class for the Cloudinary plugin.
+ *
+ * @package Cloudinary
+ */
+
+namespace Cloudinary\Integrations;
+
+use Elementor\Core\Files\CSS\Post;
+use Elementor\Element_Base;
+use Elementor\Plugin;
+
+/**
+ * Class Elementor
+ */
+class Elementor extends Integrations {
+
+	/**
+	 * Check if the integration can be enabled.
+	 *
+	 * @return bool
+	 */
+	public function can_enable() {
+		return class_exists( 'Elementor\Plugin' );
+	}
+
+	/**
+	 * Register hooks for the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'elementor/element/parse_css', array( $this, 'replace_bg_images_in_css' ), 10, 2 );
+	}
+
+	/**
+	 * Replace all background images URLs with Cloudinary URLs, within the generated Elementor CSS file.
+	 *
+	 * @param Post         $post_css The post CSS object.
+	 * @param Element_Base $element  The Elementor element.
+	 * @return void
+	 */
+	public function replace_bg_images_in_css( $post_css, $element ) {
+		$media       = $this->plugin->get_component( 'media' );
+		$settings    = $element->get_settings_for_display();
+
+		// Define all background image related keys and their specificities.
+		$background_keys = array(
+			'_background_image'              => array(
+				'device' => 'desktop',
+				'suffix' => '',
+			),
+			'_background_hover_image'        => array(
+				'device' => 'desktop',
+				'suffix' => ':hover',
+			),
+			'_background_image_tablet'       => array(
+				'device' => 'tablet',
+				'suffix' => '',
+			),
+			'_background_hover_image_tablet' => array(
+				'device' => 'tablet',
+				'suffix' => ':hover',
+			),
+			'_background_image_mobile'       => array(
+				'device' => 'mobile',
+				'suffix' => '',
+			),
+			'_background_hover_image_mobile' => array(
+				'device' => 'mobile',
+				'suffix' => ':hover',
+			),
+		);
+
+		foreach ( $background_keys as $background_key => $background_data ) {
+			if ( ! isset( $settings[ $background_key ]['url'], $settings[ $background_key ]['id'] ) ) {
+				continue;
+			}
+
+			$original_url = $settings[ $background_key ]['url'];
+			$media_id     = $settings[ $background_key ]['id'];
+			$media_size   = isset( $settings[ $background_key ]['size'] ) ? $settings[ $background_key ]['size'] : array();
+
+			$cloudinary_url = $media->cloudinary_url( $media_id, $media_size );
+
+			// Skip if the URL is unchanged or the cloudinary URL cannot be generated somehow.
+			if ( ! $cloudinary_url || $cloudinary_url === $original_url ) {
+				continue;
+			}
+
+			// Build the CSS selector and rule.
+			$css_selector = $post_css->get_element_unique_selector( $element ) . $background_data['suffix'];
+			$css_rule     = array( 'background-image' => "url('$cloudinary_url')" );
+
+			// Retrieve the specific media query rule for non-desktop devices.
+			$media_query = null;
+			$device      = $background_data['device']; // either 'desktop', 'tablet' or 'mobile'.
+			if ( 'desktop' !== $device ) {
+				$media_query = array( 'max' => $device );
+			}
+
+			$post_css->get_stylesheet()->add_rules( $css_selector, $css_rule, $media_query );
+		}
+	}
+}

--- a/php/integrations/class-elementor.php
+++ b/php/integrations/class-elementor.php
@@ -17,35 +17,17 @@ use Elementor\Plugin;
 class Elementor extends Integrations {
 
 	/**
-	 * List of Elementor background image settings keys, along with their device and CSS suffix.
+	 * List of Elementor background image settings keys.
 	 *
 	 * @var array
 	 */
 	const ELEMENTOR_BACKGROUND_IMAGES = array(
-		'background_image'              => array(
-			'device' => 'desktop',
-			'suffix' => '',
-		),
-		'background_hover_image'        => array(
-			'device' => 'desktop',
-			'suffix' => ':hover',
-		),
-		'background_image_tablet'       => array(
-			'device' => 'tablet',
-			'suffix' => '',
-		),
-		'background_hover_image_tablet' => array(
-			'device' => 'tablet',
-			'suffix' => ':hover',
-		),
-		'background_image_mobile'       => array(
-			'device' => 'mobile',
-			'suffix' => '',
-		),
-		'background_hover_image_mobile' => array(
-			'device' => 'mobile',
-			'suffix' => ':hover',
-		),
+		'background_image',
+		'background_hover_image',
+		'background_image_tablet',
+		'background_hover_image_tablet',
+		'background_image_mobile',
+		'background_hover_image_mobile',
 	);
 
 	/**
@@ -87,7 +69,7 @@ class Elementor extends Integrations {
 			return;
 		}
 
-		foreach ( self::ELEMENTOR_BACKGROUND_IMAGES as $background_key => $background_data ) {
+		foreach ( self::ELEMENTOR_BACKGROUND_IMAGES as $background_key ) {
 			$background   = null;
 			$is_container = false;
 
@@ -127,15 +109,18 @@ class Elementor extends Integrations {
 				return;
 			}
 
-			// Elementor applies this suffix rule to container background images to avoid conflicts with motion effects backgrounds.
-			$default_suffix = $is_container ? ':not(.elementor-motion-effects-element-type-background)' : '';
-			$css_selector   = $unique_selector . $default_suffix . $background_data['suffix'];
-			$css_rule       = array( 'background-image' => "url('$cloudinary_url')" );
+			// Determine if it's a hover background.
+			$is_hover = ( strpos( $background_key, 'hover' ) !== false );
 
-			// Retrieve the specific media query rule for non-desktop devices.
+			$css_selector = $this->build_background_image_css_selector( $unique_selector, $is_container, $is_hover );
+			$css_rule     = array( 'background-image' => "url('$cloudinary_url')" );
+
+			// Retrieve the specific media query rule for non-desktop devices based on the setting key.
 			$media_query = null;
-			if ( 'desktop' !== $background_data['device'] ) {
-				$media_query = array( 'max' => $background_data['device'] );
+			if ( strpos( $background_key, 'tablet' ) !== false ) {
+				$media_query = array( 'max' => 'tablet' );
+			} elseif ( strpos( $background_key, 'mobile' ) !== false ) {
+				$media_query = array( 'max' => 'mobile' );
 			}
 
 			$success = $this->override_elementor_css_rule( $post_css, $css_selector, $css_rule, $media_query );
@@ -199,5 +184,32 @@ class Elementor extends Integrations {
 
 		$stylesheet->add_rules( $css_selector, $css_rule, $media_query );
 		return true;
+	}
+
+	/**
+	 * Build the full CSS selector for background image replacement.
+	 *
+	 * @param string $unique_selector The unique selector for the element.
+	 * @param bool   $is_container    Whether the element is a container (section/column).
+	 * @param bool   $is_hover        Whether the background is for hover state.
+	 *
+	 * @return string
+	 */
+	private function build_background_image_css_selector( $unique_selector, $is_container, $is_hover ) {
+		// For hover backgrounds, we simply append :hover to the unique selector.
+		if ( $is_hover ) {
+			return $unique_selector . ':hover';
+		}
+
+		// For non-container elements, we can return the unique selector as is.
+		if ( ! $is_container ) {
+			return $unique_selector;
+		}
+
+		// For container elements, we need to replicate the specific selector Elementor uses for background images.
+		return sprintf(
+			'%1$s:not(.elementor-motion-effects-element-type-background), %1$s > .elementor-motion-effects-container > .elementor-motion-effects-layer',
+			$unique_selector
+		);
 	}
 }

--- a/php/integrations/class-elementor.php
+++ b/php/integrations/class-elementor.php
@@ -28,6 +28,12 @@ class Elementor extends Integrations {
 		'background_hover_image_tablet',
 		'background_image_mobile',
 		'background_hover_image_mobile',
+		'background_overlay_image',
+		'background_overlay_hover_image',
+		'background_overlay_image_tablet',
+		'background_overlay_hover_image_tablet',
+		'background_overlay_image_mobile',
+		'background_overlay_hover_image_mobile',
 	);
 
 	/**
@@ -109,10 +115,10 @@ class Elementor extends Integrations {
 				return;
 			}
 
-			// Determine if it's a hover background.
-			$is_hover = ( strpos( $background_key, 'hover' ) !== false );
-
-			$css_selector = $this->build_background_image_css_selector( $unique_selector, $is_container, $is_hover );
+			// Build the CSS selector and rule for background image replacement.
+			$is_hover     = ( strpos( $background_key, 'hover' ) !== false );
+			$is_overlay   = ( strpos( $background_key, 'overlay' ) !== false );
+			$css_selector = $this->build_background_image_css_selector( $unique_selector, $is_container, $is_hover, $is_overlay );
 			$css_rule     = array( 'background-image' => "url('$cloudinary_url')" );
 
 			// Retrieve the specific media query rule for non-desktop devices based on the setting key.
@@ -188,14 +194,42 @@ class Elementor extends Integrations {
 
 	/**
 	 * Build the full CSS selector for background image replacement.
+	 * We try to match the exact Elementor formatting and rules, so that our CSS overrides the previous rules,
+	 * instead of adding new rules within the CSS which may not apply for specific edge cases (e.g. specific child elements).
 	 *
 	 * @param string $unique_selector The unique selector for the element.
 	 * @param bool   $is_container    Whether the element is a container (section/column).
 	 * @param bool   $is_hover        Whether the background is for hover state.
+	 * @param bool   $is_overlay      Whether the background is for an overlay.
 	 *
 	 * @return string
 	 */
-	private function build_background_image_css_selector( $unique_selector, $is_container, $is_hover ) {
+	private function build_background_image_css_selector( $unique_selector, $is_container, $is_hover, $is_overlay ) {
+		if ( $is_overlay ) {
+			// Overlay backgrounds need to target multiple pseudo-elements and child elements.
+			$overlay_selector = sprintf(
+				'%1$s%2$s::before,
+				%1$s%2$s > .elementor-background-video-container::before,
+				%1$s%2$s > .e-con-inner > .elementor-background-video-container::before,
+				%1$s > .elementor-background-slideshow%2$s::before,
+				%1$s > .e-con-inner > .elementor-background-slideshow%2$s::before',
+				$unique_selector,
+				$is_hover ? ':hover' : ''
+			);
+
+			// For non-hover overlays, we need to also target motion effects layers.
+			if ( ! $is_hover ) {
+				$overlay_selector = sprintf(
+					'%1$s,
+					%2$s > .elementor-motion-effects-container > .elementor-motion-effects-layer::before',
+					$overlay_selector,
+					$unique_selector
+				);
+			}
+
+			// Replace any newline and extra spaces to match the exact Elementor formatting.
+			return preg_replace( '/\s+/', ' ', $overlay_selector );
+		}
 		// For hover backgrounds, we simply append :hover to the unique selector.
 		if ( $is_hover ) {
 			return $unique_selector . ':hover';
@@ -206,7 +240,7 @@ class Elementor extends Integrations {
 			return $unique_selector;
 		}
 
-		// For container elements, we need to replicate the specific selector Elementor uses for background images.
+		// For container elements, we need to target both the element itself and its motion effects layers.
 		return sprintf(
 			'%1$s:not(.elementor-motion-effects-element-type-background), %1$s > .elementor-motion-effects-container > .elementor-motion-effects-layer',
 			$unique_selector


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
This ensures that background images generated within Elementor's CSS files are handled accordingly.


## Approach

- Hook into the Elementor parse_css hook. 
  - Check for any background image elementor keys
  - Generate the corresponding cloudinary URL for the media
  - Inject the right CSS rule to override the default one within Elementor
- Flush the elementor cache whenever a cache flush occurs on Cloudinary
  - This ensures any setting change is directly applied for Elementor background images


## QA notes

- Activate the Elementor plugin
  - Create a page with Elementor
    - Within the elementor page, add an element like a heading
    - Edit the heading, go to _Advanced_ and open the **background** section
    - Apply a background image (and if you want, you can also apply a hover background image, or even some viewport specific ones like tablet or mobile background images)
  - Publish and view the page
  - Inspect the element and check its CSS contains the cloudinary URL for the background image
  - Go to Cloudinary -> Image Settings
    - Make some changes for instance the image format
    - Save the changes
    - Reload the elementor page and make sure the changes applied to the background image
- Deactivate the Elementor plugin
  - Make sure the Cloudinary plugin still works, and doesn't expect Elementor to be enabled 
