### PR TITLE
added default 21

### DIFF
--- a/ui-definitions/settings-pages.php
+++ b/ui-definitions/settings-pages.php
@@ -155,6 +155,7 @@ $settings = array(
 									'min' => 3,
 									'max' => 100,
 								),
+								'default'      => 21,
 							),
 							array(
 								'type'        => 'number',


### PR DESCRIPTION
## Approach

- Max images recommends a value between three and 40, but the default value that I got was 10. This is not intuitive. It needs to be the average of the recommended value. 


## QA notes
- Make sure that the default value is actually pre-populated when connecting to the plugin. 
