### PR TITLE
Improve down_sync_asset hook

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -2285,8 +2285,7 @@ class Media extends Settings_Component implements Setup {
 	 */
 	public function down_sync_asset() {
 		$nonce = Utils::get_sanitized_text( 'nonce', INPUT_POST );
-		if ( wp_verify_nonce( $nonce, 'wp_rest' ) ) {
-
+		if ( is_user_logged_in() && wp_verify_nonce( $nonce, 'wp_rest' ) && current_user_can( 'upload_files' ) ) {
 			$asset = $this->get_asset_payload();
 			// Set a base array for pulling an asset if needed.
 			$base_return = array(


### PR DESCRIPTION
## Approach

- Ensured only logged-in users with the `upload_files` capability can import assets from the DAM.


## QA notes

Cases:
- Go to the Media Library admin page and upload an asset.
- Go to a page and upload an asset.
- Import an asset from the DAM in the Media Library modal (the Cloudinary tab in the modal):
<img width="349" height="127" alt="dam-modal" src="https://github.com/user-attachments/assets/d005ca72-a294-4927-83af-16166659b9ab" />   

- Go to the Cloudinary DAM page and import an asset from the DAM.

In all of those cases, the assets should be synced.
