### PR TITLE
Organize Image Optimization options: Add f_avif support & recommend f_auto

### DIFF
--- a/ui-definitions/settings-image.php
+++ b/ui-definitions/settings-image.php
@@ -108,11 +108,12 @@ $settings = array(
 							'default'      => 'auto',
 							'options'      => array(
 								'none' => __( 'Not set', 'cloudinary' ),
-								'auto' => __( 'Auto', 'cloudinary' ),
+								'auto' => __( 'Auto (Recommended)', 'cloudinary' ),
 								'png'  => __( 'PNG', 'cloudinary' ),
 								'jpg'  => __( 'JPG', 'cloudinary' ),
 								'gif'  => __( 'GIF', 'cloudinary' ),
 								'webp' => __( 'WebP', 'cloudinary' ),
+								'avif' => __( 'AVIF', 'cloudinary' ),
 							),
 							'suffix'       => 'f_@value',
 							'attributes'   => array(


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->


## Approach

Improve the image optimization setting options:
- Add the **AVIF** option within the dropdown which will set the value to `f_avif`
- Rename the label for the f_auto option to read as `Auto (Recommended)`


## QA notes

- Go to the **Image Settings** page
  - Set the **Image Format** to `Auto (Recommended)`
  - Save the changes
- On a post/page:
  - add a new image
  - save the changes and view the page on the frontend
  - make sure the image is being served using the `f_auto` format option
- Repeat the steps above but this time by setting the **Image Format** to `AVIF`
