### PR TITLE
Fix PHP warning on is_cloudinary_url method

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1981,7 +1981,7 @@ class Media extends Settings_Component implements Setup {
 		$test_parts = wp_parse_url( $url );
 		$cld_url    = wp_parse_url( $this->base_url, PHP_URL_HOST );
 
-		return isset( $test_parts['path'] ) && false !== strpos( $test_parts['host'], $cld_url );
+		return isset( $test_parts['path'], $test_parts['host'] ) && false !== strpos( $test_parts['host'], $cld_url );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->
Fixes #1146 


## Approach

- Verify the _host_ part of the URL being checked is set
- This prevents any PHP warning being emitted for a few specific URL formats


## QA notes

- Turn on WP debug logging by adding the following to your _wp-config.php_:
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
```
- Add the following one-liner to either your theme, or within a plugin:
```php
add_action( 'admin_init', fn() => \Cloudinary\get_plugin_instance()->get_component( 'media' )->is_cloudinary_url( 'mailto:test@example.com' ) );
```
- Open the WP admin in your browser
  - without this fix, your _wp-content/debug.log_ file should contain a warning like this one: `PHP Warning: Undefined array key "host"`
  - with this fix, the warning should be gone