### PR TITLE
feat: sanitize CLOUDINARY_URL= prefix and add inline format hint in w…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "phpcompatibility/phpcompatibility-wp": "dev-master",
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
     "automattic/vipwpcs": "^3.0",
-    "wp-coding-standards/wpcs": "^3.0"
+    "wp-coding-standards/wpcs": "^3.0",
+    "phpunit/phpunit": "^9.6"
   },
   "config": {
     "platform": {
@@ -27,6 +28,9 @@
     ],
     "fix": [
       "phpcbf"
+    ],
+    "test": [
+      "phpunit"
     ]
   },
   "minimum-stability": "dev"

--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -94,6 +94,22 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 	const CLOUDINARY_VARIABLE_REGEX = '^(?:CLOUDINARY_URL=)?cloudinary://[0-9]+:[A-Za-z_\-0-9]+@[A-Za-z]+';
 
 	/**
+	 * Sanitize a raw connection URL input.
+	 *
+	 * Strips leading/trailing whitespace and the optional CLOUDINARY_URL= prefix
+	 * (case-insensitive), which users sometimes copy verbatim from their dashboard.
+	 *
+	 * @param string $url The raw URL string.
+	 *
+	 * @return string
+	 */
+	public static function sanitize_connection_url( $url ) {
+		$url = trim( (string) $url );
+		$url = preg_replace( '/^CLOUDINARY_URL=/i', '', $url );
+		return trim( $url );
+	}
+
+	/**
 	 * Initiate the plugin resources.
 	 *
 	 * @param \Cloudinary\Plugin $plugin Instance of the plugin.
@@ -150,7 +166,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 	 */
 	public function rest_test_connection( WP_REST_Request $request ) {
 
-		$url    = $request->get_param( 'cloudinary_url' );
+		$url    = self::sanitize_connection_url( (string) $request->get_param( 'cloudinary_url' ) );
 		$result = $this->test_connection( $url );
 
 		return rest_ensure_response( $result );
@@ -273,7 +289,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 			return $data;
 		}
 
-		$data['cloudinary_url'] = str_replace( 'CLOUDINARY_URL=', '', $data['cloudinary_url'] );
+		$data['cloudinary_url'] = self::sanitize_connection_url( $data['cloudinary_url'] );
 		$current                = $this->plugin->settings->find_setting( 'connect' )->get_value();
 
 		// Same URL, return original data.
@@ -904,7 +920,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		}
 
 		// Test upgraded details.
-		$data['cloudinary_url'] = str_replace( 'CLOUDINARY_URL=', '', $data['cloudinary_url'] );
+		$data['cloudinary_url'] = self::sanitize_connection_url( $data['cloudinary_url'] );
 		$test                   = $this->test_connection( $data['cloudinary_url'] );
 
 		if ( 'connection_success' === $test['type'] ) {
@@ -943,7 +959,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		static $url = null;
 
 		if ( empty( $url ) ) {
-			$url = str_replace( 'CLOUDINARY_URL=', '', CLOUDINARY_CONNECTION_STRING );
+			$url = self::sanitize_connection_url( CLOUDINARY_CONNECTION_STRING );
 		}
 
 		if ( 'cloudinary_url' === $setting ) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/php/bootstrap.php"
+    colors="true"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/php</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">php</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/js/components/wizard.js
+++ b/src/js/components/wizard.js
@@ -28,6 +28,7 @@ const Wizard = {
 		error: document.getElementById( 'connection-error' ),
 		success: document.getElementById( 'connection-success' ),
 		working: document.getElementById( 'connection-working' ),
+		formatHint: document.getElementById( 'connection-format-hint' ),
 	},
 	debounceConnect: null,
 	updateConnection: document.getElementById( 'update-connection' ),
@@ -93,13 +94,13 @@ const Wizard = {
 		} );
 		connectionInput.addEventListener( 'input', ( ev ) => {
 			this.lockNext();
-			const value = connectionInput.value.replace(
-				'CLOUDINARY_URL=',
-				''
-			);
+			const value = connectionInput.value
+				.replace( /^CLOUDINARY_URL=/i, '' )
+				.trim();
 			this.connection.error.classList.remove( 'active' );
 			this.connection.success.classList.remove( 'active' );
 			this.connection.working.classList.remove( 'active' );
+			this.connection.formatHint.classList.add( 'hidden' );
 			if ( value.length ) {
 				this.testing = value;
 				if ( this.debounceConnect ) {
@@ -258,10 +259,12 @@ const Wizard = {
 	showError() {
 		this.connection.error.classList.add( 'active' );
 		this.connection.success.classList.remove( 'active' );
+		this.connection.formatHint.classList.remove( 'hidden' );
 	},
 	showSuccess() {
 		this.connection.error.classList.remove( 'active' );
 		this.connection.success.classList.add( 'active' );
+		this.connection.formatHint.classList.add( 'hidden' );
 	},
 	show( item ) {
 		item.classList.remove( 'hidden' );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * Defines the minimal WordPress function stubs needed to load class-connect.php
+ * in isolation, without a full WordPress installation.
+ *
+ * @package Cloudinary
+ */
+
+// Autoload the plugin's PHP classes.
+spl_autoload_register(
+	function ( $class ) {
+		$prefix = 'Cloudinary\\';
+		if ( 0 !== strpos( $class, $prefix ) ) {
+			return;
+		}
+
+		$relative = str_replace( $prefix, '', $class );
+		$relative = strtolower( str_replace( array( '\\', '_' ), array( '/', '-' ), $relative ) );
+		$file     = __DIR__ . '/../../php/' . $relative . '.php';
+
+		// Also try class- prefix convention.
+		if ( ! file_exists( $file ) ) {
+			$parts    = explode( '/', $relative );
+			$last     = array_pop( $parts );
+			$parts[]  = 'class-' . $last;
+			$file     = __DIR__ . '/../../php/' . implode( '/', $parts ) . '.php';
+		}
+
+		if ( file_exists( $file ) ) {
+			require_once $file;
+		}
+	}
+);
+
+// ---------------------------------------------------------------------------
+// Minimal WordPress stubs so class-connect.php can be parsed without WP core.
+// ---------------------------------------------------------------------------
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Stub for wp_parse_url().
+	 *
+	 * @param string   $url       The URL.
+	 * @param int      $component Optional PHP_URL_* constant.
+	 * @return array|string|int|null
+	 */
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	/** Stub for add_filter(). */
+	function add_filter() {}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	/** Stub for add_action(). */
+	function add_action() {}
+}
+
+if ( ! function_exists( '__' ) ) {
+	/**
+	 * Stub for __().
+	 *
+	 * @param string $text   The text.
+	 * @param string $domain Text domain.
+	 * @return string
+	 */
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	/**
+	 * Stub for is_wp_error().
+	 *
+	 * @param mixed $thing Value to check.
+	 * @return bool
+	 */
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	/** Minimal WP_Error stub. */
+	class WP_Error {
+		/** @var string */
+		private $code;
+		/** @var string */
+		private $message;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $code    Error code.
+		 * @param string $message Error message.
+		 */
+		public function __construct( $code = '', $message = '' ) {
+			$this->code    = $code;
+			$this->message = $message;
+		}
+
+		/** @return string */
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		/** @return string */
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}

--- a/tests/php/test-class-connect.php
+++ b/tests/php/test-class-connect.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Unit tests for Cloudinary\Connect.
+ *
+ * Covers sanitize_connection_url() and the CLOUDINARY_VARIABLE_REGEX constant
+ * which are pure-PHP helpers with no WordPress runtime dependencies.
+ *
+ * Run with:
+ *   vendor/bin/phpunit --testdox
+ *
+ * @package Cloudinary
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Connect::sanitize_connection_url() and CLOUDINARY_VARIABLE_REGEX.
+ */
+class Test_Connect extends TestCase {
+
+	// -----------------------------------------------------------------------
+	// sanitize_connection_url()
+	// -----------------------------------------------------------------------
+
+	/** @test */
+	public function it_returns_a_plain_url_unchanged() {
+		$url = 'cloudinary://123456789012345:AbCdEfGhIjKlMnOpQrStUvWxYz@mycloud';
+		$this->assertSame( $url, Cloudinary\Connect::sanitize_connection_url( $url ) );
+	}
+
+	/** @test */
+	public function it_strips_uppercase_cloudinary_url_prefix() {
+		$raw      = 'CLOUDINARY_URL=cloudinary://123:secret@cloud';
+		$expected = 'cloudinary://123:secret@cloud';
+		$this->assertSame( $expected, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	/** @test */
+	public function it_strips_lowercase_cloudinary_url_prefix() {
+		$raw      = 'cloudinary_url=cloudinary://123:secret@cloud';
+		$expected = 'cloudinary://123:secret@cloud';
+		$this->assertSame( $expected, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	/** @test */
+	public function it_strips_mixed_case_cloudinary_url_prefix() {
+		$raw      = 'Cloudinary_URL=cloudinary://123:secret@cloud';
+		$expected = 'cloudinary://123:secret@cloud';
+		$this->assertSame( $expected, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	/** @test */
+	public function it_trims_leading_and_trailing_whitespace() {
+		$raw      = '  cloudinary://123:secret@cloud  ';
+		$expected = 'cloudinary://123:secret@cloud';
+		$this->assertSame( $expected, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	/** @test */
+	public function it_trims_whitespace_around_a_prefixed_url() {
+		$raw      = "  CLOUDINARY_URL=cloudinary://123:secret@cloud\n";
+		$expected = 'cloudinary://123:secret@cloud';
+		$this->assertSame( $expected, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	/** @test */
+	public function it_returns_an_empty_string_for_empty_input() {
+		$this->assertSame( '', Cloudinary\Connect::sanitize_connection_url( '' ) );
+	}
+
+	/** @test */
+	public function it_casts_non_string_input_to_string() {
+		// null cast to (string) is ''; prefix-only strings become empty.
+		$this->assertSame( '', Cloudinary\Connect::sanitize_connection_url( null ) );
+	}
+
+	/** @test */
+	public function it_does_not_strip_prefix_that_appears_mid_string() {
+		// The regex is anchored to ^, so an embedded occurrence is left alone.
+		$raw = 'cloudinary://123:CLOUDINARY_URL=secret@cloud';
+		$this->assertSame( $raw, Cloudinary\Connect::sanitize_connection_url( $raw ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// CLOUDINARY_VARIABLE_REGEX
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Helper: run the regex against a (pre-sanitized) URL.
+	 *
+	 * @param string $url URL to test.
+	 * @return bool
+	 */
+	private function matches_regex( $url ) {
+		return (bool) preg_match(
+			'~' . Cloudinary\Connect::CLOUDINARY_VARIABLE_REGEX . '~',
+			$url
+		);
+	}
+
+	/** @test */
+	public function regex_accepts_a_valid_url_without_prefix() {
+		$this->assertTrue( $this->matches_regex( 'cloudinary://123456:AbC-dEf_0@mycloud' ) );
+	}
+
+	/** @test */
+	public function regex_accepts_a_valid_url_with_uppercase_prefix() {
+		// The regex itself still allows the prefix; sanitize_connection_url() removes
+		// it before storage, but the regex must tolerate it during the transition.
+		$this->assertTrue( $this->matches_regex( 'CLOUDINARY_URL=cloudinary://123456:AbC@mycloud' ) );
+	}
+
+	/** @test */
+	public function regex_rejects_a_url_missing_the_cloudinary_scheme() {
+		$this->assertFalse( $this->matches_regex( 'https://123456:secret@mycloud' ) );
+	}
+
+	/** @test */
+	public function regex_rejects_a_url_with_non_numeric_api_key() {
+		$this->assertFalse( $this->matches_regex( 'cloudinary://NOT_A_NUMBER:secret@mycloud' ) );
+	}
+
+	/** @test */
+	public function regex_rejects_a_url_missing_the_cloud_name() {
+		// Missing host part – '@' at end with nothing following.
+		$this->assertFalse( $this->matches_regex( 'cloudinary://123:secret@' ) );
+	}
+
+	/** @test */
+	public function regex_rejects_an_empty_string() {
+		$this->assertFalse( $this->matches_regex( '' ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// Integration: sanitize then validate
+	// -----------------------------------------------------------------------
+
+	/** @test */
+	public function sanitized_prefixed_url_passes_regex_validation() {
+		$raw       = 'CLOUDINARY_URL=cloudinary://987654321:MySecret_Key-01@production';
+		$sanitized = Cloudinary\Connect::sanitize_connection_url( $raw );
+		$this->assertTrue( $this->matches_regex( $sanitized ) );
+	}
+
+	/** @test */
+	public function sanitized_whitespace_padded_url_passes_regex_validation() {
+		$raw       = "  cloudinary://111222333:pass@staging  \n";
+		$sanitized = Cloudinary\Connect::sanitize_connection_url( $raw );
+		$this->assertTrue( $this->matches_regex( $sanitized ) );
+	}
+
+	/** @test */
+	public function malformed_url_fails_even_after_sanitization() {
+		// Missing API secret.
+		$raw       = 'CLOUDINARY_URL=cloudinary://123456@cloud';
+		$sanitized = Cloudinary\Connect::sanitize_connection_url( $raw );
+		$this->assertFalse( $this->matches_regex( $sanitized ) );
+	}
+}

--- a/ui-definitions/components/wizard.php
+++ b/ui-definitions/components/wizard.php
@@ -149,6 +149,9 @@ $advanced->set_value( 'on' );
 					<span id="connection-error" class="cld-wizard-connect-status error">
 						<span class="dashicons dashicons-warning"></span> <?php esc_html_e( 'Incorrect connection string', 'cloudinary' ); ?>
 					</span>
+					<p id="connection-format-hint" class="cld-wizard-connect-format-hint hidden">
+						<?php esc_html_e( 'Expected format:', 'cloudinary' ); ?> <code>cloudinary://API_KEY:API_SECRET@CLOUD_NAME</code>
+					</p>
 					<span id="connection-working" class="cld-wizard-connect-status working">
 						<span class="spinner"></span>
 					</span>


### PR DESCRIPTION
…izard

- Add Connect::sanitize_connection_url() — strips the CLOUDINARY_URL= prefix (case-insensitive) and trims surrounding whitespace, covering the common copy-paste pattern from the Cloudinary dashboard.
- Wire the new method into verify_connection(), rest_test_connection(), upgrade_connection(), and maybe_connection_string_constant(), replacing the previous case-sensitive str_replace() calls.
- Wizard PHP: add #connection-format-hint <p> beneath the error indicator so users see the expected URL format inline without leaving the page.
- Wizard JS: expose formatHint in the connection object; show the hint in showError(), hide it in showSuccess() and on each new keystroke; upgrade the prefix-strip regex from literal string to /^CLOUDINARY_URL=/i with a .trim() so leading/trailing whitespace is also handled client-side.
- Add PHPUnit 9 test suite (tests/php/test-class-connect.php) covering sanitize_connection_url() (8 cases) and CLOUDINARY_VARIABLE_REGEX (6 cases), plus 3 sanitize-then-validate integration tests. Bootstrap stubs the minimal WP functions so tests run without a WP installation.
- Add phpunit/phpunit ^9.6 to composer require-dev and create phpunit.xml.dist.

<!-- Please reference the issue number this pull request addresses. -->
Fixes #123


## Approach

- Describe the approach and the suggested implementation.


## QA notes

- Detail the steps needed to verify the PR.
