### PR TITLE
Fix WPML integration for Cloudinary media inserted prior to WPML activation

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1350,7 +1350,7 @@ class Delivery implements Setup {
 			'resource_type' => $resource_type,
 		);
 
-		$tag_element['atts']['data-public-id'] = $this->plugin->get_component( 'connect' )->api->get_public_id( $tag_element['id'], $args );
+		$tag_element['atts']['data-public-id'] = $this->plugin->get_component( 'connect' )->api->get_public_id( $tag_element['id'], $args, $public_id );
 
 		return $tag_element;
 	}

--- a/php/class-utils.php
+++ b/php/class-utils.php
@@ -1088,15 +1088,7 @@ class Utils {
 		 */
 		$media_context_query = apply_filters( 'cloudinary_media_context_query', 'media_context = %s' );
 
-		/**
-		 * Filter the media context things.
-		 *
-		 * @hook   cloudinary_media_context_things
-		 * @since  3.2.0
-		 * @param $media_context_things {array} The default media context things.
-		 * @return {array}
-		 */
-		$media_context_things = apply_filters( 'cloudinary_media_context_things', array( 'default' ) );
+		$media_context_things = self::get_media_context_things();
 
 		// Query for urls in chunks.
 		if ( ! empty( $urls ) ) {
@@ -1259,6 +1251,28 @@ class Utils {
 		$context = apply_filters( 'cloudinary_media_context', 'default', $attachment_id );
 
 		return sanitize_key( $context );
+	}
+
+	/**
+	 * Get the media context things.
+	 *
+	 * @param array $media_context_things The media context things to query for. Defaults to array( 'default' ).
+	 *
+	 * @return array
+	 */
+	public static function get_media_context_things( $media_context_things = array( 'default' ) ) {
+
+		/**
+		 * Filter the media context things.
+		 *
+		 * @hook   cloudinary_media_context_things
+		 * @since  3.2.0
+		 * @param $media_context_things {array} The default media context things.
+		 * @return {array}
+		 */
+		$media_context_things = apply_filters( 'cloudinary_media_context_things', $media_context_things );
+
+		return $media_context_things;
 	}
 
 	/**

--- a/php/relate/class-relationship.php
+++ b/php/relate/class-relationship.php
@@ -79,9 +79,22 @@ class Relationship {
 			return $cache_data;
 		}
 		global $wpdb;
-		$table_name = Utils::get_relationship_table();
+		$table_name       = Utils::get_relationship_table();
+		$default_contexts = Utils::get_media_context_things();
 
-		$sql  = $wpdb->prepare( "SELECT * FROM {$table_name} WHERE post_id = %d AND media_context = %s", $this->post_id, $this->context ); // phpcs:ignore WordPress.DB
+		// If the context is in the default contexts, we want to query for all of them.
+		// This ensures that a media uploaded with a previous default context will still be found, even if the default context has changed since it was uploaded.
+		$contexts = in_array( $this->context, $default_contexts, true ) ? $default_contexts : array( $this->context );
+
+		// Create the context query placeholders by filling an array with the correct number of %s placeholders and then imploding it into a string.
+		$context_query = implode( ', ', array_fill( 0, count( $contexts ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB
+		$sql  = $wpdb->prepare(
+			"SELECT * FROM {$table_name} WHERE `post_id` = %d AND `media_context` IN ({$context_query})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+			$this->post_id,
+			...$contexts
+		);
 		$data = $wpdb->get_row( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB
 
 		self::set_cache( $this->post_id, $this->context, $data );

--- a/php/relate/class-relationship.php
+++ b/php/relate/class-relationship.php
@@ -89,11 +89,17 @@ class Relationship {
 		// Create the context query placeholders by filling an array with the correct number of %s placeholders and then imploding it into a string.
 		$context_query = implode( ', ', array_fill( 0, count( $contexts ), '%s' ) );
 
+		// Prepare arguments for the SQL query.
+		$query_args = array_merge(
+			array( $this->post_id ),
+			$contexts,
+			array( $this->context )
+		);
+
 		// phpcs:ignore WordPress.DB
 		$sql  = $wpdb->prepare(
-			"SELECT * FROM {$table_name} WHERE `post_id` = %d AND `media_context` IN ({$context_query})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
-			$this->post_id,
-			...$contexts
+			"SELECT * FROM {$table_name} WHERE `post_id` = %d AND `media_context` IN ({$context_query}) ORDER BY FIELD(`media_context`, %s) DESC LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+			$query_args
 		);
 		$data = $wpdb->get_row( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB
 


### PR DESCRIPTION
<!-- Please reference the issue number this pull request addresses. -->

## The issue

When Cloudinary is enabled without WPML, `cloudinary_relationships` entries are inserted with a `media_context` set to `default`.

Once WPML is activated though, new `cloudinary_relationships` entries have their `media_context` set to the current language (e.g. `en` for English). 
Furthermore, when posts are looking for the relationships data for specific images, it currently attempts to fetch them using the current language for context.
This works well in the case where WPML was activated prior to Cloudinary, however creates some issues when activation is done the other way around:

- Posts created with cloudinary assets prior to WPML activation are tagged with the media_context set to default
- Once WPML is active, the queries for the posts would then look for media_context = `en` and therefore won't find the corresponding cloudinary_relationships entries, resulting in not found assets
- This issue is particularly noticeable on lazy-loading. Eager-loading implementation in Cloudinary already had a fallback in place to use the public ID found from the local URL. Which makes it work, but isn't a bulletproof solution

## Approach

- On lazy-loading, apply the same fallback to use the local URL public ID if relationship entry cannot be found
- Adapt the query to also look for media_context = default, so that we can still fetch these if needed.

## QA notes

- Make sure Cloudinary plugin is active and configured, but WPML is not activated yet
- Create a post and insert a Cloudinary asset within it
- Then, activate WPML plugin
  - Note: if you don't have it, this is a paid plugin. You'll need to:
    - Download the **OTGS Installer** plugin from their site
    - Activate it, and make it install and activate the **WPML Multilingual CMS** plugin
- View the previously created post to make sure the asset is shown
  - Try with both lazy-loading enabled and disabled, via the **Cloudinary -> Lazy Loading** settings page
 