### PR TITLE
Add proper uninstall.php and extract shared Cleanup class

### DIFF
--- a/php/class-cleanup.php
+++ b/php/class-cleanup.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Shared cleanup routines for uninstall and destructive deactivation.
+ *
+ * @package Cloudinary
+ */
+
+namespace Cloudinary;
+
+use Cloudinary\Media\Global_Transformations;
+
+/**
+ * Class Cleanup
+ */
+class Cleanup {
+
+	/**
+	 * Option key used to flag an in-progress cleanup operation.
+	 *
+	 * @var string
+	 */
+	const CLEANING_KEY = 'cloudinary_cleaning_up';
+
+	/**
+	 * The plugin instance.
+	 *
+	 * @var Plugin|null
+	 */
+	protected $plugin;
+
+	/**
+	 * The plugin settings object.
+	 *
+	 * @var Settings|null
+	 */
+	protected $settings;
+
+	/**
+	 * Cleanup constructor.
+	 *
+	 * @param Plugin|null   $plugin   Plugin instance.
+	 * @param Settings|null $settings Settings instance.
+	 */
+	public function __construct( Plugin $plugin = null, Settings $settings = null ) {
+		$this->plugin = $plugin;
+
+		if ( null !== $settings ) {
+			$this->settings = $settings;
+		} elseif ( $plugin instanceof Plugin && $plugin->settings instanceof Settings ) {
+			$this->settings = $plugin->settings;
+		}
+	}
+
+	/**
+	 * Run the full cleanup routine.
+	 *
+	 * @param Plugin|null   $plugin   Plugin instance.
+	 * @param Settings|null $settings Settings instance.
+	 */
+	public static function run( Plugin $plugin = null, Settings $settings = null ) {
+		$cleanup = new self( $plugin, $settings );
+		$cleanup->cleanup_user_data();
+		$cleanup->cleanup_post_meta();
+		$cleanup->cleanup_term_meta();
+		$cleanup->cleanup_post_type();
+		$cleanup->drop_tables();
+		$cleanup->cleanup_options();
+		$cleanup->cleanup_cron();
+		$cleanup->cleanup_legacy_cron();
+	}
+
+	/**
+	 * Cleanup Cloudinary's user data related.
+	 */
+	protected function cleanup_user_data() {
+		$user_meta_keys = array(
+			'_cld_ui_state',
+		);
+
+		foreach ( $user_meta_keys as $key ) {
+			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
+			delete_metadata( 'user', null, $key, '', true );
+		}
+	}
+
+	/**
+	 * Cleanup Cloudinary's post meta related.
+	 */
+	protected function cleanup_post_meta() {
+		$post_meta_keys = array_merge(
+			Sync::META_KEYS,
+			array(
+				Global_Transformations::META_FEATURED_IMAGE_KEY,
+				Global_Transformations::META_ORDER_KEY . '_terms',
+				Delivery::META_CACHE_KEY,
+			)
+		);
+
+		foreach ( $post_meta_keys as $key ) {
+			delete_post_meta_by_key( $key );
+		}
+	}
+
+	/**
+	 * Cleanup Cloudinary's term meta related.
+	 */
+	protected function cleanup_term_meta() {
+		$term_meta_keys = array(
+			'cloudinary_transformations_image_freeform',
+			'cloudinary_transformations_video_freeform',
+		);
+
+		foreach ( $term_meta_keys as $key ) {
+			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
+			delete_metadata( 'term', null, $key, '', true );
+		}
+	}
+
+	/**
+	 * Cleanup Cloudinary's post types related.
+	 */
+	protected function cleanup_post_type() {
+		global $wpdb;
+
+		$post_types = array(
+			Assets::POST_TYPE_SLUG,
+		);
+
+		foreach ( $post_types as $type ) {
+			$wpdb->delete( //phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$wpdb->posts,
+				array( 'post_type' => $type ),
+				array( '%s' )
+			);
+		}
+	}
+
+	/**
+	 * Drop Cloudinary's tables.
+	 */
+	protected function drop_tables() {
+		global $wpdb;
+
+		$tables = array(
+			Utils::get_relationship_table(),
+		);
+
+		foreach ( $tables as $table ) {
+			$wpdb->query( "DROP TABLE IF EXISTS {$table};" ); // phpcs:ignore WordPress.DB
+		}
+	}
+
+	/**
+	 * Cleanup Cloudinary's options related.
+	 */
+	protected function cleanup_options() {
+		if ( $this->settings instanceof Settings ) {
+			$all = $this->settings->get_param( 'settings' );
+			if ( is_array( $all ) ) {
+				foreach ( $all as $slug => $setting ) {
+					$this->settings->delete( $slug );
+				}
+			}
+		}
+
+		if ( $this->plugin instanceof Plugin ) {
+			$sync = $this->plugin->get_component( 'sync' );
+			if ( $sync instanceof Sync && ! empty( $sync->managers['queue'] ) ) {
+				$queue       = $sync->managers['queue'];
+				$all_threads = $queue->get_threads( 'all' );
+				foreach ( $all_threads as $threads ) {
+					foreach ( $threads as $thread ) {
+						$queue->reset_thread_queue( $thread );
+						delete_post_meta_by_key( $thread );
+					}
+				}
+			}
+		}
+
+		$storage_keys = array();
+		if ( $this->settings instanceof Settings ) {
+			$storage_keys = (array) $this->settings->get_storage_keys();
+		}
+
+		$option_keys = array_merge(
+			$storage_keys,
+			array(
+				'cloudinary_setup',
+				'cloudinary_main_cache_page',
+				'_cld_disable_http_upload',
+				Report::REPORT_KEY,
+				Media::GLOBAL_VIDEO_TRANSFORMATIONS,
+				self::CLEANING_KEY,
+			)
+		);
+
+		$option_keys = array_unique( array_filter( $option_keys ) );
+		foreach ( $option_keys as $key ) {
+			delete_option( $key );
+			delete_transient( $key );
+		}
+	}
+
+	/**
+	 * Remove all cron-related tasks.
+	 *
+	 * @return void
+	 */
+	protected function cleanup_cron() {
+		// Get the Cron instance.
+		$cron_instance = Cron::get_instance();
+		$schedule      = $cron_instance->get_schedule();
+
+		// Unregister all registered schedules.
+		if ( ! empty( $schedule ) ) {
+			foreach ( array_keys( $schedule ) as $schedule_name ) {
+				$cron_instance->unregister_schedule( $schedule_name );
+			}
+		}
+
+		// Remove any lock files or objects used by the Locker instance.
+		$cron_instance->cleanup_locker();
+
+		// Delete the cron schedule option saved in database.
+		delete_option( Cron::CRON_META_KEY );
+	}
+
+	/**
+	 * Cleanup legacy cron jobs.
+	 *
+	 * @return void
+	 */
+	protected function cleanup_legacy_cron() {
+		wp_clear_scheduled_hook( 'cloudinary_status' );
+
+		$jobs = array(
+			'cloudinary_cleanup_event',
+			'cloudinary_rest_api_connectivity',
+			'cloudinary_resume_queue',
+			'cloudinary_resume_upgrade',
+			'cloudinary_sync_items',
+		);
+
+		foreach ( $jobs as $job ) {
+			$time = wp_next_scheduled( $job );
+			if ( false !== $time ) {
+				wp_clear_scheduled_hook( $job );
+			}
+		}
+	}
+}

--- a/php/class-deactivation.php
+++ b/php/class-deactivation.php
@@ -7,8 +7,6 @@
 
 namespace Cloudinary;
 
-use Cloudinary\Media\Global_Transformations;
-use Cloudinary\Sync\Storage;
 use WP_Error;
 use WP_HTTP_Response;
 use WP_REST_Request;
@@ -45,13 +43,6 @@ class Deactivation {
 	 * @var Settings
 	 */
 	protected $settings;
-
-	/**
-	 * Cleaning data key.
-	 *
-	 * @var string
-	 */
-	const CLEANING_KEY = 'cloudinary_cleaning_up';
 
 	/**
 	 * Initiate the plugin deactivation.
@@ -459,7 +450,7 @@ class Deactivation {
 			$actions['deactivate'] = str_replace( '<a ', '<a class="cld-deactivate-link" ', $actions['deactivate'] );
 		}
 
-		if ( get_option( self::CLEANING_KEY ) ) {
+		if ( get_option( Cleanup::CLEANING_KEY ) ) {
 			$actions['deactivate'] = __( 'Data clean up. The plugin will self deactivate once complete. ', 'cloudinary' );
 		}
 
@@ -470,182 +461,8 @@ class Deactivation {
 	 * Cleanup Cloudinary data.
 	 */
 	protected function cleanup() {
-		wp_schedule_single_event( time() + 5 * MINUTE_IN_SECONDS, 'cloudinary_cleanup_event' );
-		add_option( self::CLEANING_KEY, true, '', false );
-		$this->cleanup_user_data();
-		$this->cleanup_post_meta();
-		$this->cleanup_term_meta();
-		$this->cleanup_post_type();
-		$this->drop_tables();
-		$this->cleanup_options();
-		$this->cleanup_cron();
-		$this->cleanup_legacy_cron();
-
-		// If we got this far, let's remove the cron event.
+		add_option( Cleanup::CLEANING_KEY, true, '', false );
+		Cleanup::run( $this->plugin, $this->settings );
 		wp_clear_scheduled_hook( 'cloudinary_cleanup_event' );
-	}
-
-	/**
-	 * Cleanup Cloudinary's user data related.
-	 */
-	protected function cleanup_user_data() {
-		$user_meta_keys = array(
-			'_cld_ui_state',
-		);
-
-		foreach ( $user_meta_keys as $key ) {
-			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
-			delete_metadata( 'user', null, $key, '', true );
-		}
-	}
-
-	/**
-	 * Cleanup Cloudinary's post meta related.
-	 */
-	protected function cleanup_post_meta() {
-		$post_meta_keys = array_merge(
-			Sync::META_KEYS,
-			array(
-				Global_Transformations::META_FEATURED_IMAGE_KEY,
-				Global_Transformations::META_ORDER_KEY . '_terms',
-				Delivery::META_CACHE_KEY,
-			)
-		);
-
-		foreach ( $post_meta_keys as $key ) {
-			delete_post_meta_by_key( $key );
-		}
-	}
-
-	/**
-	 * Cleanup Cloudinary's term meta related.
-	 */
-	protected function cleanup_term_meta() {
-		$term_meta_keys = array(
-			'cloudinary_transformations_image_freeform',
-			'cloudinary_transformations_video_freeform',
-		);
-
-		foreach ( $term_meta_keys as $key ) {
-			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
-			delete_metadata( 'term', null, $key, '', true );
-		}
-	}
-
-	/**
-	 * Drop Cloudinary's tables.
-	 */
-	protected function drop_tables() {
-		global $wpdb;
-
-		$tables = array(
-			Utils::get_relationship_table(),
-		);
-
-		foreach ( $tables as $table ) {
-			$wpdb->query( "DROP TABLE IF EXISTS {$table};" ); // phpcs:ignore WordPress.DB
-		}
-	}
-
-	/**
-	 * Cleanup Cloudinary's post types related.
-	 */
-	protected function cleanup_post_type() {
-		global $wpdb;
-
-		$post_types = array(
-			Assets::POST_TYPE_SLUG,
-		);
-
-		foreach ( $post_types as $type ) {
-			$wpdb->delete( //phpcs:ignore WordPress.DB.DirectDatabaseQuery
-				$wpdb->posts,
-				array( 'post_type' => $type ),
-				array( '%s' )
-			);
-		}
-	}
-
-	/**
-	 * Cleanup Cloudinary's options related.
-	 */
-	protected function cleanup_options() {
-		$all = $this->settings->get_param( 'settings' );
-		foreach ( $all as $slug => $setting ) {
-			$this->settings->delete( $slug );
-		}
-
-		$queue       = $this->plugin->get_component( 'sync' )->managers['queue'];
-		$all_threads = $queue->get_threads( 'all' );
-		foreach ( $all_threads as $threads ) {
-			foreach ( $threads as $thread ) {
-				$queue->reset_thread_queue( $thread );
-				delete_post_meta_by_key( $thread );
-			}
-		}
-
-		$option_keys = array_merge(
-			$this->settings->get_storage_keys(),
-			array(
-				'cloudinary_setup',
-				'cloudinary_main_cache_page',
-				'_cld_disable_http_upload',
-				Report::REPORT_KEY,
-				Media::GLOBAL_VIDEO_TRANSFORMATIONS,
-				self::CLEANING_KEY,
-			)
-		);
-
-		foreach ( $option_keys as $key ) {
-			delete_option( $key );
-			delete_transient( $key );
-		}
-	}
-
-	/**
-	 * Remove all cron-related tasks.
-	 *
-	 * @return void
-	 */
-	protected function cleanup_cron() {
-		// Get the Cron instance.
-		$cron_instance = Cron::get_instance();
-		$schedule      = $cron_instance->get_schedule();
-
-		// Unregister all registered schedules.
-		if ( ! empty( $schedule ) ) {
-			foreach ( array_keys( $schedule ) as $schedule_name ) {
-				$cron_instance->unregister_schedule( $schedule_name );
-			}
-		}
-
-		// Remove any lock files or objects used by the Locker instance.
-		$cron_instance->cleanup_locker();
-
-		// Delete the cron schedule option saved in database.
-		delete_option( Cron::CRON_META_KEY );
-	}
-
-	/**
-	 * Cleanup legacy cron jobs.
-	 *
-	 * @return void
-	 */
-	protected function cleanup_legacy_cron() {
-		wp_clear_scheduled_hook( 'cloudinary_status' );
-
-		$jobs = array(
-			'cloudinary_rest_api_connectivity',
-			'cloudinary_resume_queue',
-			'cloudinary_resume_upgrade',
-			'cloudinary_sync_items',
-		);
-
-		foreach ( $jobs as $job ) {
-			$time = wp_next_scheduled( $job );
-			if ( false !== $time ) {
-				wp_clear_scheduled_hook( $job );
-			}
-		}
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Uninstall handler for Cloudinary.
+ *
+ * @package Cloudinary
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+define( 'CLDN_CORE', __DIR__ . '/cloudinary.php' );
+define( 'CLDN_PATH', plugin_dir_path( CLDN_CORE ) );
+
+require_once __DIR__ . '/instance.php';
+
+$plugin = \Cloudinary\get_plugin_instance();
+
+// Bootstrap enough runtime state for component-aware cleanup.
+$plugin->init();
+$plugin->plugins_loaded();
+$plugin->setup_settings();
+
+\Cloudinary\Cleanup::run( $plugin );


### PR DESCRIPTION
Background
Previously, the plugin had no uninstall.php. All data removal logic lived exclusively inside Deactivation::cleanup(), which was only reachable when a user chose "Remove all plugin data" from the deactivation modal. WordPress's standard uninstall hook — triggered when a user clicks Delete in the Plugins screen — was never wired up, meaning plugin data (options, post meta, term meta, custom tables, cron jobs) was left behind after a full uninstall.

What changed
uninstall.php (new)
Registers the plugin's uninstall handler with WordPress. The file guards against direct execution via WP_UNINSTALL_PLUGIN, then bootstraps the minimum plugin runtime needed for component-aware cleanup (init → plugins_loaded → setup_settings) before delegating to Cleanup::run().

php/class-cleanup.php (new)
Extracts all data-removal routines from Deactivation into a standalone Cleanup class so the same logic can be invoked from both the deactivation modal path and the uninstall path without duplication. The class:

Accepts an optional Plugin instance and Settings instance (with a fallback to $plugin->settings)
Guards every settings-dependent branch with instanceof checks so it degrades gracefully if settings are not available
Exposes a static Cleanup::run() factory entry point
Owns the CLEANING_KEY constant (previously on Deactivation), since it is Cleanup that reads and deletes this option
Adds array_unique( array_filter(...) ) around the option-key list in cleanup_options() to prevent redundant or empty-key deletes
Adds cloudinary_cleanup_event to cleanup_legacy_cron() so that the deactivation-modal's scheduled retry hook is always cleared, regardless of which code path triggered cleanup
php/class-deactivation.php (modified)
Removes the CLEANING_KEY constant (now on Cleanup) and updates both references to Cleanup::CLEANING_KEY
Removes all private cleanup methods (moved to Cleanup)
Removes the unused use imports (Global_Transformations, Storage) that were only needed by those methods
Simplifies cleanup() to: set the cleaning flag → Cleanup::run() → clear the cron hook