### PR TITLE
Fix PHP 8.4 null deprecation warnings in class-delivery.php

### DIFF
--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1566,7 +1566,10 @@ class Delivery implements Setup {
 
 			return null;
 		}
-		$raw_url                 = 'source' === $tag_element['tag'] && ! empty( $attributes['srcset'] ) ? $attributes['srcset'] : $attributes['src'];
+		$raw_url = 'source' === $tag_element['tag'] && ! empty( $attributes['srcset'] ) ? $attributes['srcset'] : ( $attributes['src'] ?? '' );
+		if ( '' === $raw_url ) {
+			return null;
+		}
 		$url                     = $this->maybe_unsize_url( Utils::clean_url( $this->sanitize_url( $raw_url ) ) );
 		$tag_element['base_url'] = $url;
 		// Track back the found URL.
@@ -1942,6 +1945,11 @@ class Delivery implements Setup {
 	 * @return string|null
 	 */
 	protected function sanitize_url( $url ) {
+
+		// Bail early on empty or non-string URLs.
+		if ( ! is_string( $url ) || '' === $url ) {
+			return null;
+		}
 
 		// Catch mixed URLs.
 		if ( 5 < strlen( $url ) && false !== strpos( $url, 'https://', 5 ) ) {


### PR DESCRIPTION
## Issue

Reported on the [WordPress.org support forum](https://wordpress.org/support/topic/new-deprecated-warnings-with-php-8-4/): PHP 8.4 deprecation warnings from `class-delivery.php`:

```
PHP Warning:  Undefined array key "src" in php/class-delivery.php on line 1569
PHP Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in php/class-delivery.php on line 1947
PHP Deprecated: strtok(): Passing null to parameter #1 ($string) of type string is deprecated in php/class-delivery.php on line 1952
```

## Root cause

In `get_tag_element()`, the `src` attribute was dereferenced directly:

```php
$raw_url = 'source' === $tag_element['tag'] && ! empty( $attributes['srcset'] ) ? $attributes['srcset'] : $attributes['src'];
```

When a parsed tag has no `src` attribute, this emits `Undefined array key "src"` and sets `$raw_url` to `null`. That null then flows into `sanitize_url()`, where `strlen( $url )` and `strtok( $url, '?' )` trigger the PHP 8.4 deprecation notices.

## Fix

- Default a missing `src` to an empty string (`?? ''`) and bail early when there is no usable URL.
- Guard `sanitize_url()` against non-string / empty input as a defensive measure.

## QA

1. On a PHP 8.4 site with the plugin active, render markup that contains tags without a `src` attribute (or otherwise empty source).
2. Before the fix: `Undefined array key "src"` warning plus `strlen()` / `strtok()` null deprecations in the logs.
3. After the fix: no warnings; delivery filtering continues to work for valid URLs.
