### PR TITLE
Fix duplicate assets on DB write fails scenarios

### DIFF
--- a/php/sync/class-upload-sync.php
+++ b/php/sync/class-upload-sync.php
@@ -298,10 +298,11 @@ class Upload_Sync {
 	 * @param int         $attachment_id The attachment ID.
 	 * @param string|null $type          Optional Sync type.
 	 * @param string|null $suffix        An optional suffix.
+	 * @param bool        $overwrite     Whether to overwrite an existing Cloudinary asset.
 	 *
 	 * @return array|\WP_Error
 	 */
-	public function upload_asset( $attachment_id, $type = null, $suffix = null ) {
+	public function upload_asset( $attachment_id, $type = null, $suffix = null, $overwrite = false ) {
 
 		add_filter( 'cloudinary_doing_upload', '__return_true' );
 
@@ -340,6 +341,9 @@ class Upload_Sync {
 				remove_filter( 'wp_get_original_image_path', array( $this, 'filter_backup_original' ), 10 );
 				break;
 			default:
+				if ( $overwrite ) {
+					$options['overwrite'] = true;
+				}
 				$result = $this->connect->api->upload( $attachment_id, $options, array() );
 				break;
 		}
@@ -349,6 +353,11 @@ class Upload_Sync {
 
 			// Check that this wasn't an existing.
 			if ( ! empty( $result['existing'] ) ) {
+				// If no public_id is recorded in WordPress, this asset in Cloudinary is from a
+				// failed previous upload. Overwrite it instead of creating a suffixed duplicate.
+				if ( empty( $suffix ) && ! $this->media->get_post_meta( $attachment_id, Sync::META_KEYS['public_id'], true ) ) {
+					return $this->upload_asset( $attachment_id, $type, null, true );
+				}
 				// Add a suffix and try again.
 				$suffix = '_' . $attachment_id . substr( strrev( uniqid() ), 0, 5 );
 


### PR DESCRIPTION
When Cloudinary returns `existing: true` (overwrite=false, asset already exists), the plugin retried with a unique suffix, creating a new Cloudinary asset. If the server killed the PHP process after the upload but before saving `_public_id`, WordPress never recorded the asset. Each subsequent autosync cycle repeated this, producing one new Cloudinary duplicate per cycle (102 in the reported case).

When WordPress has no `_public_id` for an attachment, the conflicting Cloudinary asset is from a previously failed upload attempt. Overwriting it is safe and avoids creating another suffixed duplicate.

## Approach

- In the specific scenario detailed above, we tell Cloudinary to overwrite the assets on upload instead of uploading a new assets

## QA notes

### Steps to reproduce

- Upload a new image in the media library
  - wait a few seconds until it's synced to Cloudinary
  - Make note of the attachment ID
- In your terminal run the following commands (replace the **123** IDs with your attachement ID):
  - Replicate the stuck step: `npx wp-env run cli wp eval '$m = get_post_meta(123, "_cloudinary", true); $m["_public_id"] = ""; $m["_sync_signature"] = []; update_post_meta(123, "_cloudinary", $m); echo "Done\n";'`
  - Trigger the upload: `npx wp-env run cli wp eval 'Cloudinary\get_plugin_instance()->get_component("sync")->managers["push"]->process_assets(123);'`
  - Check the saved public_id: `npx wp-env run cli wp eval 'echo get_post_meta(123, "_cloudinary", true)["_public_id"] . "\n";'`

**On `master` branch**: the public_id will have a suffix like _123_xxxxx, meaning the asset is duplicated within Cloudinary's backend. 

**On this branch**: the original public_id won't have a suffix, indicating that it was overwritten instead of duplicated.
