### PR TITLE
Fix: don't force non-crop size slugs to exact dimensions

### DIFF
--- a/php/class-media.php
+++ b/php/class-media.php
@@ -3301,6 +3301,16 @@ class Media extends Settings_Component implements Setup {
 
 		$size_data = $image_subsizes[ $size_slug ];
 
+		// A non-crop ( crop => false ) size is a maximum bounding box, not exact dimensions.
+		// WordPress scales such images to fit inside the box while preserving the aspect ratio,
+		// so the registered width/height must not be treated as a fixed crop. Doing so forces
+		// non-square images into the box dimensions ( e.g. the default `large` 1024x1024 becomes
+		// w_1024,h_1024,c_scale ), visibly stretching landscape/portrait assets. Only hard-crop
+		// sizes have exact dimensions worth pinning here.
+		if ( empty( $size_data['crop'] ) ) {
+			return null;
+		}
+
 		// Return width and height if both are present and valid.
 		if ( ! empty( $size_data['width'] ) && ! empty( $size_data['height'] ) ) {
 			return array( (int) $size_data['width'], (int) $size_data['height'] );


### PR DESCRIPTION
`get_size_from_slug()` returned the registered width/height from `wp_get_registered_image_subsizes()` for any matching slug, ignoring the `crop` flag. For non-crop sizes ( crop => false ) those values are a maximum bounding box, not exact dimensions: WordPress scales the image to fit inside the box while preserving aspect ratio.

Treating them as a fixed crop made the delivery layer emit, for the default `large` ( 1024x1024, crop => false ), a transformation of `w_1024,h_1024,c_scale` applied to a landscape/portrait source, visibly stretching it into a square. This surfaced on blocks whose stored `<img src>` had no size suffix (so the URL-based size lookup returned nothing and the figure-class slug fallback ran).

Return early for non-crop sizes so only genuine hard-crop sizes are pinned to exact dimensions.

<!-- Please reference the issue number this pull request addresses. -->
Fixes #123


## Approach

- Describe the approach and the suggested implementation.


## QA notes

- Detail the steps needed to verify the PR.
