### PR TITLE
Bump PHPStan to level 2 and fix all resulting issues

### DIFF
--- a/php/cache/class-cache-point.php
+++ b/php/cache/class-cache-point.php
@@ -34,7 +34,7 @@ class Cache_Point {
 	/**
 	 * Holds a list of pre-found cached urls before querying to find cached items
 	 *
-	 * @var array.
+	 * @var array
 	 */
 	protected $pre_cached = array();
 	/**

--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -38,7 +38,7 @@ class Admin {
 	/**
 	 * Holds notices object.
 	 *
-	 * @var Settings
+	 * @var Setting
 	 */
 	protected $notices;
 

--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -522,9 +522,10 @@ class Admin {
 	}
 
 	/**
-	 * Get admin notices.
+	 * Absorb WordPress settings errors into the plugin notice store and return
+	 * the renderable notice setting, if any notices are pending.
 	 *
-	 * @return Setting[]
+	 * @return Setting|null
 	 */
 	public function get_admin_notices() {
 		$setting_notices = get_settings_errors();
@@ -532,6 +533,13 @@ class Admin {
 			$this->add_admin_notice( $notice['code'], $notice['message'], $notice['type'], true );
 		}
 
-		return $setting_notices;
+		$notices = $this->notices->get_value();
+		if ( empty( $notices ) ) {
+			return null;
+		}
+
+		sort( $notices );
+
+		return $this->init_components( $notices, self::NOTICE_SLUG );
 	}
 }

--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -1141,7 +1141,7 @@ class Assets extends Settings_Component {
 	 *
 	 * @param int $asset_id The asset id.
 	 *
-	 * @return \WP_Post|null;
+	 * @return \WP_Post|null
 	 */
 	public function find_parent( $asset_id ) {
 		$path   = $this->clean_path( $this->media->local_url( $asset_id ) );
@@ -1792,7 +1792,8 @@ class Assets extends Settings_Component {
 	 */
 	protected function add_asset_parent( $post ) {
 		if ( is_multisite() ) {
-			$post->blog_id = get_current_blog_id();
+			// Dynamically stash the current blog ID on the post object for later multisite checks.
+			$post->blog_id = get_current_blog_id(); // @phpstan-ignore property.notFound
 		}
 
 		$this->asset_parents[ $post->post_title ] = $post;

--- a/php/class-cache.php
+++ b/php/class-cache.php
@@ -10,7 +10,6 @@ namespace Cloudinary;
 use Cloudinary\Cache\Cache_Point;
 use Cloudinary\Cache\File_System;
 use Cloudinary\Component\Setup;
-use Cloudinary\Settings\Setting;
 use WP_Error;
 use WP_HTTP_Response;
 use WP_REST_Request;
@@ -720,33 +719,17 @@ class Cache extends Settings_Component implements Setup {
 	}
 
 	/**
-	 * Adds the individual setting tabs.
+	 * Register the cache-path hooks for each cache tab.
+	 *
+	 * The settings structures themselves are registered declaratively via
+	 * settings(); this only wires the per-tab cache_point path callbacks that
+	 * run on the cloudinary_cache_init_cache_points action.
 	 */
 	protected function setup_setting_tabs() {
-		$cache_settings = $this->get_cache_settings();
-		foreach ( $cache_settings as $setting ) {
-			$callback = $setting->get_param( 'callback' );
-			if ( is_callable( $callback ) ) {
-				call_user_func( $callback ); // Init the settings.
-			}
-		}
-	}
-
-	/**
-	 * Get all the Cache settings.
-	 *
-	 * @return Setting[]
-	 */
-	public function get_cache_settings() {
-		static $settings = array();
-		if ( empty( $settings ) ) {
-			$main_setting = $this->settings->get_setting( 'cache_paths' );
-			foreach ( $main_setting->get_settings() as $slug => $setting ) {
-				$settings[ $slug ] = $setting;
-			}
-		}
-
-		return $settings;
+		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_plugin_cache_paths' ) );
+		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_theme_cache_paths' ) );
+		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_wp_cache_paths' ) );
+		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_content_cache_paths' ) );
 	}
 
 	/**
@@ -783,7 +766,9 @@ class Cache extends Settings_Component implements Setup {
 	}
 
 	/**
-	 * Add the plugin cache settings page.
+	 * Get the plugin cache settings structure.
+	 *
+	 * @return array
 	 */
 	protected function add_plugin_settings() {
 
@@ -821,8 +806,8 @@ class Cache extends Settings_Component implements Setup {
 				$plugins_setup,
 			),
 		);
-		$this->settings->create_setting( 'plugins_settings', $params, $this->settings->get_setting( 'cache_plugins' ) );
-		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_plugin_cache_paths' ) );
+
+		return $params;
 	}
 
 	/**
@@ -834,7 +819,9 @@ class Cache extends Settings_Component implements Setup {
 	}
 
 	/**
-	 * Add Theme Settings page.
+	 * Get the theme cache settings structure.
+	 *
+	 * @return array
 	 */
 	protected function add_theme_settings() {
 
@@ -873,8 +860,7 @@ class Cache extends Settings_Component implements Setup {
 			),
 		);
 
-		$this->settings->create_setting( 'theme_settings', $params, $this->settings->get_setting( 'cache_themes' ) );
-		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_theme_cache_paths' ) );
+		return $params;
 	}
 
 	/**
@@ -886,7 +872,9 @@ class Cache extends Settings_Component implements Setup {
 	}
 
 	/**
-	 * Add WP Settings page.
+	 * Get the WordPress cache settings structure.
+	 *
+	 * @return array
 	 */
 	protected function add_wp_settings() {
 
@@ -925,8 +913,7 @@ class Cache extends Settings_Component implements Setup {
 			),
 		);
 
-		$this->settings->create_setting( 'wordpress_settings', $params, $this->settings->get_setting( 'cache_wordpress' ) );
-		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_wp_cache_paths' ) );
+		return $params;
 	}
 
 	/**
@@ -938,7 +925,9 @@ class Cache extends Settings_Component implements Setup {
 	}
 
 	/**
-	 * Add WP Settings page.
+	 * Get the content cache settings structure.
+	 *
+	 * @return array
 	 */
 	protected function add_content_settings() {
 
@@ -977,8 +966,7 @@ class Cache extends Settings_Component implements Setup {
 			),
 		);
 
-		$this->settings->create_setting( 'content_settings', $params, $this->settings->get_setting( 'cache_content' ) );
-		add_action( 'cloudinary_cache_init_cache_points', array( $this, 'add_content_cache_paths' ) );
+		return $params;
 	}
 
 	/**
@@ -1046,24 +1034,24 @@ class Cache extends Settings_Component implements Setup {
 							'default'      => 'off',
 						),
 						array(
-							'slug'     => 'cache_plugins',
-							'type'     => 'frame',
-							'callback' => array( $this, 'add_plugin_settings' ),
+							'slug' => 'cache_plugins',
+							'type' => 'frame',
+							$this->add_plugin_settings(),
 						),
 						array(
-							'slug'     => 'cache_themes',
-							'type'     => 'frame',
-							'callback' => array( $this, 'add_theme_settings' ),
+							'slug' => 'cache_themes',
+							'type' => 'frame',
+							$this->add_theme_settings(),
 						),
 						array(
-							'slug'     => 'cache_wordpress',
-							'type'     => 'frame',
-							'callback' => array( $this, 'add_wp_settings' ),
+							'slug' => 'cache_wordpress',
+							'type' => 'frame',
+							$this->add_wp_settings(),
 						),
 						array(
-							'slug'     => 'cache_content',
-							'type'     => 'frame',
-							'callback' => array( $this, 'add_content_settings' ),
+							'slug' => 'cache_content',
+							'type' => 'frame',
+							$this->add_content_settings(),
 						),
 					),
 					array(

--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -153,7 +153,11 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		$url    = $request->get_param( 'cloudinary_url' );
 		$result = $this->test_connection( $url );
 
-		/** @var \Cloudinary\Analytics $analytics */
+		/**
+		 * The analytics component.
+		 *
+		 * @var \Cloudinary\Analytics $analytics
+		 */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$success = isset( $result['type'] ) && 'connection_success' === $result['type'];
@@ -241,7 +245,11 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 			);
 		}
 
-		/** @var \Cloudinary\Analytics $analytics */
+		/**
+		 * The analytics component.
+		 *
+		 * @var \Cloudinary\Analytics $analytics
+		 */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$analytics->track(

--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -153,6 +153,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		$url    = $request->get_param( 'cloudinary_url' );
 		$result = $this->test_connection( $url );
 
+		/** @var \Cloudinary\Analytics $analytics */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$success = isset( $result['type'] ) && 'connection_success' === $result['type'];
@@ -240,6 +241,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 			);
 		}
 
+		/** @var \Cloudinary\Analytics $analytics */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$analytics->track(

--- a/php/class-dashboard.php
+++ b/php/class-dashboard.php
@@ -37,9 +37,17 @@ class Dashboard {
 	 * @return bool
 	 */
 	public function has_data() {
-		/** @var \Cloudinary\Sync $sync */
+		/**
+		 * The sync component.
+		 *
+		 * @var \Cloudinary\Sync $sync
+		 */
 		$sync = $this->plugin->get_component( 'sync' );
-		/** @var \Cloudinary\Sync\Sync_Queue $queue */
+		/**
+		 * The sync queue manager.
+		 *
+		 * @var \Cloudinary\Sync\Sync_Queue $queue
+		 */
 		$queue = $sync->managers['queue'];
 		$data  = $queue->get_total_synced_media();
 

--- a/php/class-dashboard.php
+++ b/php/class-dashboard.php
@@ -37,8 +37,11 @@ class Dashboard {
 	 * @return bool
 	 */
 	public function has_data() {
+		/** @var \Cloudinary\Sync $sync */
 		$sync = $this->plugin->get_component( 'sync' );
-		$data = $sync->managers['queue']->get_total_synced_media();
+		/** @var \Cloudinary\Sync\Sync_Queue $queue */
+		$queue = $sync->managers['queue'];
+		$data  = $queue->get_total_synced_media();
 
 		return ! empty( $data );
 	}

--- a/php/class-deactivation.php
+++ b/php/class-deactivation.php
@@ -575,6 +575,7 @@ class Deactivation {
 			$this->settings->delete( $slug );
 		}
 
+		/** @var \Cloudinary\Sync\Sync_Queue $queue */
 		$queue       = $this->plugin->get_component( 'sync' )->managers['queue'];
 		$all_threads = $queue->get_threads( 'all' );
 		foreach ( $all_threads as $threads ) {

--- a/php/class-deactivation.php
+++ b/php/class-deactivation.php
@@ -575,7 +575,11 @@ class Deactivation {
 			$this->settings->delete( $slug );
 		}
 
-		/** @var \Cloudinary\Sync\Sync_Queue $queue */
+		/**
+		 * The sync queue manager.
+		 *
+		 * @var \Cloudinary\Sync\Sync_Queue $queue
+		 */
 		$queue       = $this->plugin->get_component( 'sync' )->managers['queue'];
 		$all_threads = $queue->get_threads( 'all' );
 		foreach ( $all_threads as $threads ) {

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -162,11 +162,11 @@ class Delivery implements Setup {
 	/**
 	 * Determine if attributes should be added to image tags.
 	 *
-	 * @param WP_REST_Response     $response The response object.
-	 * @param WP_REST_Server       $handler  The request handler.
-	 * @param WP_REST_Request|null $request The request object, if available.
+	 * @param \WP_REST_Response     $response The response object.
+	 * @param \WP_REST_Server       $handler  The request handler.
+	 * @param \WP_REST_Request|null $request The request object, if available.
 	 *
-	 * @return WP_REST_Response
+	 * @return \WP_REST_Response
 	 */
 	public function maybe_unset_attributes( $response, $handler, $request ) {
 		$route = $request->get_route();
@@ -2110,7 +2110,9 @@ class Delivery implements Setup {
 
 		// Check if we are saving. If so, bail.
 		// This is to prevent the replacement from happening in the shutdown, signaling content changes in the editor.
-		if ( $this->plugin->get_component( 'replace' )->doing_save() ) {
+		/** @var \Cloudinary\String_Replace $replace */
+		$replace = $this->plugin->get_component( 'replace' );
+		if ( $replace->doing_save() ) {
 			return;
 		}
 		$this->init_delivery();

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -2110,7 +2110,11 @@ class Delivery implements Setup {
 
 		// Check if we are saving. If so, bail.
 		// This is to prevent the replacement from happening in the shutdown, signaling content changes in the editor.
-		/** @var \Cloudinary\String_Replace $replace */
+		/**
+		 * The string replace component.
+		 *
+		 * @var \Cloudinary\String_Replace $replace
+		 */
 		$replace = $this->plugin->get_component( 'replace' );
 		if ( $replace->doing_save() ) {
 			return;

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -38,7 +38,7 @@ class Media extends Settings_Component implements Setup {
 	 *
 	 * @since   0.1
 	 *
-	 * @var     string.
+	 * @var     string
 	 */
 	public $base_url;
 
@@ -47,7 +47,7 @@ class Media extends Settings_Component implements Setup {
 	 *
 	 * @since   0.1
 	 *
-	 * @var     string.
+	 * @var     string
 	 */
 	private $cloudinary_folder;
 
@@ -56,49 +56,49 @@ class Media extends Settings_Component implements Setup {
 	 *
 	 * @since   0.1
 	 *
-	 * @var     array.
+	 * @var     array
 	 */
 	private $cloudinary_ids = array();
 
 	/**
 	 * Cloudinary credentials.
 	 *
-	 * @var array.
+	 * @var array
 	 */
 	public $credentials;
 
 	/**
 	 * Cloudinary url filtering instance.
 	 *
-	 * @var \Cloudinary\Media\Filter.
+	 * @var \Cloudinary\Media\Filter
 	 */
 	public $filter;
 
 	/**
 	 * Cloudinary upgrade instance.
 	 *
-	 * @var \Cloudinary\Media\Upgrade.
+	 * @var \Cloudinary\Media\Upgrade
 	 */
 	public $upgrade;
 
 	/**
 	 * Cloudinary global transformations.
 	 *
-	 * @var \Cloudinary\Media\Global_Transformations.
+	 * @var \Cloudinary\Media\Global_Transformations
 	 */
 	public $global_transformations;
 
 	/**
 	 * Video filter instance.
 	 *
-	 * @var \Cloudinary\Media\Video.
+	 * @var \Cloudinary\Media\Video
 	 */
 	public $video;
 
 	/**
 	 * Gallery instance.
 	 *
-	 * @var \Cloudinary\Media\Gallery.
+	 * @var \Cloudinary\Media\Gallery
 	 */
 	public $gallery;
 
@@ -3275,7 +3275,7 @@ class Media extends Settings_Component implements Setup {
 			// Update value.
 			$setting->set_value( $media );
 			// Save to DB.
-			$setting->save_value();
+			$setting->save_value( $media );
 		}
 	}
 

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -265,7 +265,11 @@ final class Plugin {
 		$components = array_filter( $this->components, array( $this, 'is_config_component' ) );
 
 		foreach ( $components as $slug => $component ) {
-			/** @var Config $component */
+			/**
+			 * Component that implements Config.
+			 *
+			 * @var Config $component
+			 */
 			$component->get_config();
 		}
 	}

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -242,7 +242,7 @@ final class Plugin {
 			/**
 			 * Component that implements Settings.
 			 *
-			 * @var  Component\Settings $component
+			 * @var  Settings_Component $component
 			 */
 			$component->init_settings( $this->settings );
 
@@ -265,6 +265,7 @@ final class Plugin {
 		$components = array_filter( $this->components, array( $this, 'is_config_component' ) );
 
 		foreach ( $components as $slug => $component ) {
+			/** @var Config $component */
 			$component->get_config();
 		}
 	}
@@ -481,7 +482,7 @@ final class Plugin {
 		/**
 		 * An array of classes that implement the Notice interface.
 		 *
-		 * @var $components Notice[]
+		 * @var Notice[] $components
 		 */
 		$components = array_filter( $this->components, array( $this, 'is_notice_component' ) );
 		$default    = array(

--- a/php/class-settings.php
+++ b/php/class-settings.php
@@ -15,6 +15,8 @@ use Cloudinary\Settings\Storage\Storage;
  * Class Settings
  *
  * @package Cloudinary
+ *
+ * @property-read Setting|null $image_settings Chainable access to the image_settings child setting.
  */
 class Settings {
 
@@ -338,7 +340,7 @@ class Settings {
 	/**
 	 * Get a setting value.
 	 *
-	 * @param [string] ...$slugs Additional slugs to get settings for.
+	 * @param string ...$slugs Additional slugs to get settings for.
 	 *
 	 * @return mixed
 	 */

--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -606,8 +606,10 @@ class Sync implements Setup, Assets {
 				'generate' => array( $this->managers['connect'], 'get_cloud_name' ),
 				'validate' => function ( $attachment_id ) {
 
-					$valid       = true;
-					$credentials = $this->managers['connect']->get_credentials();
+					$valid = true;
+					/** @var \Cloudinary\Connect $connect */
+					$connect     = $this->managers['connect'];
+					$credentials = $connect->get_credentials();
 					if ( isset( $credentials['cname'] ) ) {
 						$url = get_post_meta( $attachment_id, '_wp_attached_file', true );
 						if ( wp_http_validate_url( $url ) ) {
@@ -1049,8 +1051,10 @@ class Sync implements Setup, Assets {
 	 */
 	public function init_background_upload() {
 		if ( ! empty( $this->to_sync ) ) {
-			$this->managers['queue']->add_to_queue( $this->to_sync, 'autosync' );
-			$this->managers['queue']->start_threads( 'autosync' );
+			/** @var \Cloudinary\Sync\Sync_Queue $queue */
+			$queue = $this->managers['queue'];
+			$queue->add_to_queue( $this->to_sync, 'autosync' );
+			$queue->start_threads( 'autosync' );
 		}
 	}
 

--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -607,7 +607,11 @@ class Sync implements Setup, Assets {
 				'validate' => function ( $attachment_id ) {
 
 					$valid = true;
-					/** @var \Cloudinary\Connect $connect */
+					/**
+					 * The connect manager.
+					 *
+					 * @var \Cloudinary\Connect $connect
+					 */
 					$connect     = $this->managers['connect'];
 					$credentials = $connect->get_credentials();
 					if ( isset( $credentials['cname'] ) ) {
@@ -1051,7 +1055,11 @@ class Sync implements Setup, Assets {
 	 */
 	public function init_background_upload() {
 		if ( ! empty( $this->to_sync ) ) {
-			/** @var \Cloudinary\Sync\Sync_Queue $queue */
+			/**
+			 * The sync queue manager.
+			 *
+			 * @var \Cloudinary\Sync\Sync_Queue $queue
+			 */
 			$queue = $this->managers['queue'];
 			$queue->add_to_queue( $this->to_sync, 'autosync' );
 			$queue->start_threads( 'autosync' );

--- a/php/class-url.php
+++ b/php/class-url.php
@@ -51,7 +51,7 @@ class URL implements Setup {
 	/**
 	 * Holds a list of the WordPress URL objects.
 	 *
-	 * @var array
+	 * @var WordPress[]
 	 */
 	protected $wordpress_urls = array();
 
@@ -120,7 +120,7 @@ class URL implements Setup {
 	 *
 	 * @param string $url The WordPress URL to break apart.
 	 *
-	 * @return array
+	 * @return WordPress
 	 */
 	public function wordpress_url( $url ) {
 		if ( ! isset( $this->wordpress_urls[ $url ] ) ) {

--- a/php/connect/class-api.php
+++ b/php/connect/class-api.php
@@ -18,6 +18,9 @@ use function Cloudinary\get_plugin_instance;
  * Class API.
  *
  * Push media to Cloudinary on upload.
+ *
+ * @method array|\WP_Error usage( string ...$args ) Get account usage stats.
+ * @method array|\WP_Error ping( string ...$args ) Ping the Cloudinary API.
  */
 class Api {
 
@@ -828,9 +831,9 @@ class Api {
 	/**
 	 * Set the POSTFIELDS to the correct array type, not the string based.
 	 *
-	 * @param \Requests_Transport_cURL $handle  The transport handle to set.
-	 * @param array                    $request The request array.
-	 * @param string                   $url     The url to send to.
+	 * @param resource $handle  The cURL handle to set.
+	 * @param array    $request The request array.
+	 * @param string   $url     The url to send to.
 	 */
 	public function set_data( $handle, $request, $url ) {
 		// Ensure that this request is in fact ours.

--- a/php/media/class-global-transformations.php
+++ b/php/media/class-global-transformations.php
@@ -326,7 +326,7 @@ class Global_Transformations {
 	/**
 	 * Check if the post has any public taxonomies.
 	 *
-	 * @param \WP_POST $post The post to check.
+	 * @param \WP_Post $post The post to check.
 	 *
 	 * @return bool
 	 */
@@ -656,7 +656,9 @@ class Global_Transformations {
 				return;
 			}
 
-			$item = $this->media->plugin->get_component( 'assets' )->get_asset( $attachment_id, 'dataset' );
+			/** @var \Cloudinary\Assets $assets */
+			$assets = $this->media->plugin->get_component( 'assets' );
+			$item   = $assets->get_asset( $attachment_id, 'dataset' );
 			if ( ! empty( $item['data']['public_id'] ) ) {
 				$text            = __( 'Add Effects', 'cloudinary' );
 				$transformations = Relate::get_transformations( $attachment_id, true, true );

--- a/php/media/class-global-transformations.php
+++ b/php/media/class-global-transformations.php
@@ -656,7 +656,11 @@ class Global_Transformations {
 				return;
 			}
 
-			/** @var \Cloudinary\Assets $assets */
+			/**
+			 * The assets component.
+			 *
+			 * @var \Cloudinary\Assets $assets
+			 */
 			$assets = $this->media->plugin->get_component( 'assets' );
 			$item   = $assets->get_asset( $attachment_id, 'dataset' );
 			if ( ! empty( $item['data']['public_id'] ) ) {

--- a/php/media/class-upgrade.php
+++ b/php/media/class-upgrade.php
@@ -197,7 +197,7 @@ class Upgrade {
 	 *
 	 * @param int $attachment_id The attachment ID to migrate.
 	 *
-	 * @return array();
+	 * @return array
 	 */
 	public function migrate_legacy_meta( $attachment_id ) {
 

--- a/php/relate/class-relationship.php
+++ b/php/relate/class-relationship.php
@@ -24,6 +24,7 @@ use function Cloudinary\get_plugin_instance;
  * @property string|null $sized_url
  * @property string|null $url_hash
  * @property string|null $media_context
+ * @property string|null $format
  */
 class Relationship {
 
@@ -32,7 +33,7 @@ class Relationship {
 	 *
 	 * @var int
 	 */
-	protected $post_id;
+	public $post_id;
 
 	/**
 	 * Flag to save the relationship on shutdown.

--- a/php/settings/class-setting.php
+++ b/php/settings/class-setting.php
@@ -15,6 +15,13 @@ use Cloudinary\UI\Component;
  * Class Setting
  *
  * @package Cloudinary\Settings
+ *
+ * Chainable child-setting access is provided dynamically via __get(). The
+ * properties documented below are the child slugs accessed directly in the
+ * codebase; the leading-underscore variant returns the child's value.
+ *
+ * @property-read Setting|null $overlay  Chainable access to the overlay child setting.
+ * @property-read mixed        $_overlay Value of the overlay child setting.
  */
 class Setting {
 

--- a/php/sync/class-push-sync.php
+++ b/php/sync/class-push-sync.php
@@ -203,6 +203,7 @@ class Push_Sync {
 		$thread = $this->plugin->settings->get_param( 'current_sync_thread' );
 
 		// Activation funnel: first sync started (emitted once per account).
+		/** @var \Cloudinary\Analytics $analytics */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$connect = $this->plugin->get_component( 'connect' );

--- a/php/sync/class-push-sync.php
+++ b/php/sync/class-push-sync.php
@@ -203,7 +203,11 @@ class Push_Sync {
 		$thread = $this->plugin->settings->get_param( 'current_sync_thread' );
 
 		// Activation funnel: first sync started (emitted once per account).
-		/** @var \Cloudinary\Analytics $analytics */
+		/**
+		 * The analytics component.
+		 *
+		 * @var \Cloudinary\Analytics $analytics
+		 */
 		$analytics = $this->plugin->get_component( 'analytics' );
 		if ( $analytics ) {
 			$connect = $this->plugin->get_component( 'connect' );

--- a/php/sync/class-sync-queue.php
+++ b/php/sync/class-sync-queue.php
@@ -137,7 +137,11 @@ class Sync_Queue {
 		// Enable sync queue.
 		if ( filter_input( INPUT_GET, 'enable-bulk', FILTER_VALIDATE_BOOLEAN ) ) {
 			$this->bulk_sync( true );
-			/** @var \Cloudinary\UI\Component\Page $page */
+			/**
+			 * The settings page component.
+			 *
+			 * @var \Cloudinary\UI\Component\Page $page
+			 */
 			$page = $this->sync->settings->get_component();
 			wp_safe_redirect( $page->get_url() );
 			exit;
@@ -145,7 +149,11 @@ class Sync_Queue {
 		// Stop sync queue.
 		if ( filter_input( INPUT_GET, 'disable-bulk', FILTER_VALIDATE_BOOLEAN ) ) {
 			$this->bulk_sync( false );
-			/** @var \Cloudinary\UI\Component\Page $page */
+			/**
+			 * The settings page component.
+			 *
+			 * @var \Cloudinary\UI\Component\Page $page
+			 */
 			$page = $this->sync->settings->get_component();
 			wp_safe_redirect( $page->get_url() );
 			exit;

--- a/php/sync/class-sync-queue.php
+++ b/php/sync/class-sync-queue.php
@@ -137,13 +137,17 @@ class Sync_Queue {
 		// Enable sync queue.
 		if ( filter_input( INPUT_GET, 'enable-bulk', FILTER_VALIDATE_BOOLEAN ) ) {
 			$this->bulk_sync( true );
-			wp_safe_redirect( $this->sync->settings->get_component()->get_url() );
+			/** @var \Cloudinary\UI\Component\Page $page */
+			$page = $this->sync->settings->get_component();
+			wp_safe_redirect( $page->get_url() );
 			exit;
 		}
 		// Stop sync queue.
 		if ( filter_input( INPUT_GET, 'disable-bulk', FILTER_VALIDATE_BOOLEAN ) ) {
 			$this->bulk_sync( false );
-			wp_safe_redirect( $this->sync->settings->get_component()->get_url() );
+			/** @var \Cloudinary\UI\Component\Page $page */
+			$page = $this->sync->settings->get_component();
+			wp_safe_redirect( $page->get_url() );
 			exit;
 		}
 

--- a/php/ui/class-branch.php
+++ b/php/ui/class-branch.php
@@ -34,7 +34,7 @@ class Branch {
 	/**
 	 * Holds the ID of the main input.
 	 *
-	 * @var array()
+	 * @var array
 	 */
 	public $main = array();
 

--- a/php/ui/component/class-asset.php
+++ b/php/ui/component/class-asset.php
@@ -156,7 +156,7 @@ class Asset extends Panel {
 	/**
 	 * Get the manager part.
 	 *
-	 * @param array $item The item to get the manager for.
+	 * @param Setting $item The item to get the manager for.
 	 *
 	 * @return array
 	 */

--- a/php/ui/component/class-cache-status.php
+++ b/php/ui/component/class-cache-status.php
@@ -33,6 +33,7 @@ class Cache_Status extends Media_Status {
 	 */
 	protected function box_status( $struct ) {
 
+		/** @var \Cloudinary\Cache $cache */
 		$cache        = $this->plugin->get_component( 'cache' );
 		$this->cache  = $cache->cache_point;
 		$cache_points = $this->cache->get_active_cache_points();

--- a/php/ui/component/class-cache-status.php
+++ b/php/ui/component/class-cache-status.php
@@ -33,7 +33,11 @@ class Cache_Status extends Media_Status {
 	 */
 	protected function box_status( $struct ) {
 
-		/** @var \Cloudinary\Cache $cache */
+		/**
+		 * The cache component.
+		 *
+		 * @var \Cloudinary\Cache $cache
+		 */
 		$cache        = $this->plugin->get_component( 'cache' );
 		$this->cache  = $cache->cache_point;
 		$cache_points = $this->cache->get_active_cache_points();
@@ -41,36 +45,44 @@ class Cache_Status extends Media_Status {
 		$title            = $this->get_part( 'h3' );
 		$title['content'] = __( 'Assets cached to Cloudinary', 'cloudinary' );
 
-		$struct['element'] = 'div';
-		$table             = array(
-			'type'    => 'table',
-			'columns' => array(
-				'cache_point'  => __( 'Cache Point', 'cloudinary' ),
-				'cached_items' => array(
-					'content'    => __( 'Cached items', 'cloudinary' ),
-					'attributes' => array(
-						'style' => 'text-align:center;',
-					),
-				),
-			),
-			'rows'    => array(),
-		);
+		$struct['element']           = 'div';
+		$struct['children']['title'] = $title;
+
+		// Table header.
+		$header_point                           = $this->get_part( 'th' );
+		$header_point['content']                = __( 'Cache Point', 'cloudinary' );
+		$header_items                           = $this->get_part( 'th' );
+		$header_items['content']                = __( 'Cached items', 'cloudinary' );
+		$header_items['attributes']['style']    = 'text-align:center;';
+		$header_row                             = $this->get_part( 'tr' );
+		$header_row['children']['cache_point']  = $header_point;
+		$header_row['children']['cached_items'] = $header_items;
+		$table_head                             = $this->get_part( 'thead' );
+		$table_head['children']['row']          = $header_row;
+
+		// Table body rows.
+		$table_body = $this->get_part( 'tbody' );
 		foreach ( $cache_points as $cache_point ) {
-			$items                             = $this->cache->get_cache_point_cache( $cache_point->ID );
-			$table['rows'][ $cache_point->ID ] = array(
-				'cache_point'  => array(
-					'content' => wp_basename( untrailingslashit( $cache_point->post_title ) ),
-				),
-				'cached_items' => array(
-					'content'    => ' ' . $items['total'] . ' ',
-					'attributes' => array(
-						'style' => 'text-align:center;',
-					),
-				),
-			);
+			$items = $this->cache->get_cache_point_cache( $cache_point->ID );
+
+			$point_cell            = $this->get_part( 'td' );
+			$point_cell['content'] = wp_basename( untrailingslashit( $cache_point->post_title ) );
+
+			$items_cell                        = $this->get_part( 'td' );
+			$items_cell['content']             = ' ' . $items['total'] . ' ';
+			$items_cell['attributes']['style'] = 'text-align:center;';
+
+			$row                                        = $this->get_part( 'tr' );
+			$row['children']['cache_point']             = $point_cell;
+			$row['children']['cached_items']            = $items_cell;
+			$table_body['children'][ $cache_point->ID ] = $row;
 		}
-		$table_obj         = $this->setting->create_setting( 'cached_status', $table, $this->setting );
-		$struct['content'] = $table_obj->render_component();
+
+		$table                        = $this->get_part( 'table' );
+		$table['attributes']['class'] = array( 'widefat', 'striped' );
+		$table['children']['head']    = $table_head;
+		$table['children']['body']    = $table_body;
+		$struct['children']['table']  = $table;
 
 		return $struct;
 	}

--- a/php/ui/component/class-connect.php
+++ b/php/ui/component/class-connect.php
@@ -28,7 +28,7 @@ class Connect extends Component {
 	/**
 	 * Holder the Connect object.
 	 *
-	 * @var Connect
+	 * @var \Cloudinary\Connect
 	 */
 	protected $connect;
 

--- a/php/ui/component/class-folder-table.php
+++ b/php/ui/component/class-folder-table.php
@@ -67,7 +67,7 @@ class Folder_Table extends Table {
 	/**
 	 * Build the header.
 	 *
-	 * @return \array[][]
+	 * @return array[][]
 	 */
 	protected function build_headers() {
 		$header_columns = array(

--- a/php/ui/component/class-line-stat.php
+++ b/php/ui/component/class-line-stat.php
@@ -86,8 +86,8 @@ class Line_Stat extends Component {
 	public function setup() {
 		parent::setup();
 		$this->set_stats();
-		$used  = $this->limit * $this->used_percent / 100;
-		$avail = $this->limit - $used;
+		$used  = (float) $this->limit * (float) $this->used_percent / 100;
+		$avail = (float) $this->limit - $used;
 		if ( $this->setting->get_param( 'format_size' ) ) {
 			$used                  = empty( $used ) ? 0 : $used;
 			$avail                 = empty( $avail ) ? 0 : $avail;

--- a/php/ui/component/class-on-off.php
+++ b/php/ui/component/class-on-off.php
@@ -92,7 +92,7 @@ class On_Off extends Text {
 			$struct['attributes']['data-main'] = wp_json_encode( $controllers );
 		}
 
-		if ( $this->is_readonly() || ( true === $this->setting->has_param( 'main_required', false ) && empty( $struct['attributes']['data-main'] ) ) ) {
+		if ( $this->is_readonly() || ( true === $this->setting->has_param( 'main_required' ) && empty( $struct['attributes']['data-main'] ) ) ) {
 			$struct['attributes']['type'] = 'hidden';
 		}
 
@@ -119,7 +119,7 @@ class On_Off extends Text {
 	 */
 	protected function shadow( $struct ) {
 		// Add the toggle stub.
-		if ( $this->is_readonly() || ( true === $this->setting->has_param( 'main_required', false ) && empty( $struct['attributes']['data-main'] ) ) ) {
+		if ( $this->is_readonly() || ( true === $this->setting->has_param( 'main_required' ) && empty( $struct['attributes']['data-main'] ) ) ) {
 			$struct                           = $this->get_part( 'input' );
 			$struct['attributes']['type']     = 'checkbox';
 			$struct['attributes']['disabled'] = 'disabled';

--- a/php/ui/component/class-opt-level.php
+++ b/php/ui/component/class-opt-level.php
@@ -157,7 +157,7 @@ class Opt_Level extends Line_Stat {
 	 */
 	protected function set_texts() {
 
-		$used_percent = round( $this->used / $this->limit * 100 );
+		$used_percent = round( (float) $this->used / (float) $this->limit * 100 );
 		/* translators: %s is the percentage optimized. */
 		$this->used_text = sprintf( __( '%s optimized', 'cloudinary' ), $used_percent . '%' );
 

--- a/php/ui/component/class-page.php
+++ b/php/ui/component/class-page.php
@@ -78,18 +78,20 @@ class Page extends Panel {
 		if ( Utils::get_active_setting() !== $this->setting ) {
 			return null;
 		}
-		$html = array();
+		/**
+		 * The admin component.
+		 *
+		 * @var \Cloudinary\Admin $admin
+		 */
+		$admin  = get_plugin_instance()->get_component( 'admin' );
+		$notice = $admin->get_admin_notices();
 
-		if ( empty( $this->setting->get_admin_notices() ) ) {
+		if ( null === $notice ) {
 			return $struct;
 		}
 
-		foreach ( $this->setting->get_admin_notices() as $setting ) {
-			$html[] = $setting->get_component()->render();
-			$setting->set_param( 'enabled', false );
-		}
 		$struct['element'] = null;
-		$struct['content'] = self::compile_html( $html );
+		$struct['content'] = $notice->get_component()->render();
 
 		return $struct;
 	}
@@ -188,9 +190,13 @@ class Page extends Panel {
 			}
 
 			// Create the link.
-			$link                       = $this->get_part( 'a' );
-			$link['content']            = $setting->get_param( 'menu_title', $setting->get_param( 'page_title' ) );
-			/** @var \Cloudinary\UI\Component\Page $page */
+			$link            = $this->get_part( 'a' );
+			$link['content'] = $setting->get_param( 'menu_title', $setting->get_param( 'page_title' ) );
+			/**
+			 * The settings page component.
+			 *
+			 * @var \Cloudinary\UI\Component\Page $page
+			 */
 			$page                       = $setting->get_component();
 			$link['attributes']['href'] = $page->get_url();
 

--- a/php/ui/component/class-page.php
+++ b/php/ui/component/class-page.php
@@ -154,7 +154,7 @@ class Page extends Panel {
 	 */
 	protected function tabs( $struct ) {
 
-		if ( $this->setting->has_param( 'has_tabs' ) && 1 < count( $this->setting->get_settings( 'page' ) ) ) {
+		if ( $this->setting->has_param( 'has_tabs' ) && 1 < count( $this->setting->get_settings() ) ) {
 			$struct['element']             = 'ul';
 			$struct['attributes']['class'] = array(
 				'cld-page-tabs',
@@ -190,7 +190,9 @@ class Page extends Panel {
 			// Create the link.
 			$link                       = $this->get_part( 'a' );
 			$link['content']            = $setting->get_param( 'menu_title', $setting->get_param( 'page_title' ) );
-			$link['attributes']['href'] = $setting->get_component()->get_url();
+			/** @var \Cloudinary\UI\Component\Page $page */
+			$page                       = $setting->get_component();
+			$link['attributes']['href'] = $page->get_url();
 
 			// Add tab to list.
 			$tab['children'][ $setting->get_slug() ] = $link;

--- a/php/ui/component/class-sync.php
+++ b/php/ui/component/class-sync.php
@@ -76,10 +76,14 @@ class Sync extends Text {
 		}
 
 		$struct['element'] = 'a';
-		/** @var \Cloudinary\UI\Component\Page $page */
-		$page              = $this->setting->find_setting( 'sync_media' )->get_component();
-		$href              = $page->get_url();
-		$args              = array();
+		/**
+		 * The settings page component.
+		 *
+		 * @var \Cloudinary\UI\Component\Page $page
+		 */
+		$page = $this->setting->find_setting( 'sync_media' )->get_component();
+		$href = $page->get_url();
+		$args = array();
 
 		if ( ! $this->setting->get_param( 'queue' )->is_enabled() ) {
 			$args['enable-bulk'] = true;

--- a/php/ui/component/class-sync.php
+++ b/php/ui/component/class-sync.php
@@ -76,7 +76,9 @@ class Sync extends Text {
 		}
 
 		$struct['element'] = 'a';
-		$href              = $this->setting->find_setting( 'sync_media' )->get_component()->get_url();
+		/** @var \Cloudinary\UI\Component\Page $page */
+		$page              = $this->setting->find_setting( 'sync_media' )->get_component();
+		$href              = $page->get_url();
 		$args              = array();
 
 		if ( ! $this->setting->get_param( 'queue' )->is_enabled() ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,7 +14,7 @@ parameters:
 		-
 			identifier: return.void
 			message: '#^Action callback returns .+ but should not return anything\.$#'
-	level: 1
+	level: 2
 	paths:
 		- php
 		- cloudinary.php
@@ -24,6 +24,7 @@ parameters:
 		- vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
 		- tests/phpstan/stubs/wpml.php
+		- tests/phpstan/stubs/elementor.php
 		- tests/phpstan/stubs/wpcom-vip.php
 		- tests/phpstan/stubs/constants.php
 	excludePaths:

--- a/tests/phpstan/stubs/elementor.php
+++ b/tests/phpstan/stubs/elementor.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Minimal Elementor stubs for static analysis.
+ *
+ * Elementor is an optional integration that is only loaded when the Elementor
+ * plugin is active. These stubs describe the small subset of Elementor's API
+ * used by the Cloudinary integration so PHPStan can analyse
+ * php/integrations/class-elementor.php.
+ *
+ * @package Cloudinary
+ */
+
+namespace Elementor {
+	class Element_Base {
+		/**
+		 * Get the element settings prepared for display.
+		 *
+		 * @return array
+		 */
+		public function get_settings_for_display() {}
+
+		/**
+		 * Get the unique CSS selector for the element.
+		 *
+		 * @return string
+		 */
+		public function get_unique_selector() {}
+	}
+
+	class Plugin {
+		/**
+		 * Holds the files manager instance.
+		 *
+		 * @var object
+		 */
+		public $files_manager;
+
+		/**
+		 * Get the Elementor plugin instance.
+		 *
+		 * @return \Elementor\Plugin
+		 */
+		public static function instance() {}
+	}
+}
+
+namespace Elementor\Core\Files\CSS {
+	use Elementor\Element_Base;
+
+	class Post {
+		/**
+		 * Get the unique selector for an element.
+		 *
+		 * @param Element_Base $element The Elementor element.
+		 *
+		 * @return string
+		 */
+		public function get_element_unique_selector( $element ) {}
+
+		/**
+		 * Get the stylesheet instance.
+		 *
+		 * @return object
+		 */
+		public function get_stylesheet() {}
+	}
+}


### PR DESCRIPTION
<!-- No tracking issue; this continues the incremental PHPStan hardening started on phpstan-level1. -->

## Approach

Raise the PHPStan analysis level from **1 to 2** and resolve all 88 resulting errors. Work is split into two commits:

**1. Bump PHPStan to level 2 and fix type/annotation issues** (81 issues, safe/mechanical)
- Correct malformed PHPDoc tags (trailing periods, invalid `array()`/`[]`/`\array` syntax, `@var $x Type` ordering).
- Use fully-qualified class names in PHPDoc where the `Cloudinary` namespace shadowed WP/global classes (`WP_REST_*`, `Cloudinary\Connect`).
- Add an Elementor stub for the optional integration and register it in `phpstan.neon.dist`.
- Narrow `get_component()` / `managers[...]` union return types at call sites so type-specific method/property access resolves.
- Add `@property`/`@method` annotations for magic `__get`/`__call` access (`Settings`, `Setting`, `Relationship`, `Api`) — the szepeviktor/phpstan-wordpress extension enforces these.
- Fix genuine argument-count/type bugs: `save_value($media)`, drop ignored extra args to `has_param()`/`get_settings()`, cast numeric stats before arithmetic, correct `WP_Post` case, make `Relationship::$post_id` public.
- Suppress one intentional dynamic `WP_Post` property write inline.

**2. Fix broken references to removed settings API** (7 issues, genuine pre-existing runtime bugs)

These referenced methods deleted in the earlier settings/UI decouple refactor (3c5cd8ac, 2021-08-27) and would fatal if executed:
- `class-cache.php`: the Site Cache tabs called the removed `Settings::create_setting()` via a callback indirection. Converted `add_plugin/theme/wp/content_settings()` to return their params and embedded them inline in `settings()` (matching the working `Assets` pattern); the `cache_point` path hooks are now registered directly in `setup_setting_tabs()`. Removed the now-unused `get_cache_settings()`.
- `class-cache-status.php`: `box_status()` built a table via the removed `create_setting()`/`render_component()`; rebuilt using the component part system so it renders correctly.
- `class-page.php` + `class-admin.php`: `notice()` called the non-existent `Setting::get_admin_notices()`; routed through the `Admin` component and had `get_admin_notices()` return the renderable notice `Setting` built via `init_components()` (consistent with `render_notices()`).

## QA notes

- Run static analysis and confirm no errors at level 2:
  ```
  composer phpstan
  ```
  Expected: `[OK] No errors`.
- Run code style on the changed files (repo-wide `composer lint` may OOM; scope to changed files with a raised limit):
  ```
  vendor/bin/phpcs -d memory_limit=1G php/class-cache.php php/class-admin.php php/ui/component/class-cache-status.php php/ui/component/class-page.php
  ```
  Expected: no errors/warnings.
- Functional smoke test of the touched runtime paths:
  - **Site Cache settings page** (Cache component) renders without fatals; plugin/theme/WordPress/content cache tabs display and their toggles work.
  - **Cache status table** renders the list of cache points with cached-item counts.
  - **Settings page notices**: trigger a settings error/notice and confirm it renders inline on the Cloudinary settings page.
  - **Analytics events** (connection test, wizard submit, first sync) still fire when the Analytics component is active.
  - **WPML** language-link asset switching still resolves the relationship `post_id`.
