### PR TITLE
Suppress content filters on internal asset bookkeeping queries

### DIFF
--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -601,7 +601,7 @@ class Assets extends Settings_Component {
 			return;
 		}
 
-		$query_args     = array(
+		$query_args = array(
 			'post_type'              => self::POST_TYPE_SLUG,
 			'posts_per_page'         => 100,
 			'post_parent'            => $parent_id,
@@ -609,6 +609,11 @@ class Assets extends Settings_Component {
 			'fields'                 => 'ids',
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
+			// Internal bookkeeping query over our own post type: do not run
+			// third-party content filters (e.g. `the_posts`) meant for
+			// public-facing queries. The query is fully specified, so the
+			// filters VIP protects (posts_where/join/orderby) are not relied on.
+			'suppress_filters'       => true, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters
 		);
 		$query          = new \WP_Query( $query_args );
 		$previous_total = $query->found_posts;
@@ -987,6 +992,11 @@ class Assets extends Settings_Component {
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
 			'update_post_term_cache' => false,
+			// Internal bookkeeping query over our own post type: do not run
+			// third-party content filters (e.g. `the_posts`) meant for
+			// public-facing queries. The query is fully specified, so the
+			// filters VIP protects (posts_where/join/orderby) are not relied on.
+			'suppress_filters'       => true, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters
 		);
 		$query               = new \WP_Query( $args );
 		$this->asset_parents = array();


### PR DESCRIPTION
## Summary

`Assets::init_asset_parents()` and `Assets::process_parent_assets()` run internal `WP_Query` lookups over Cloudinary's own asset post type. They are pure plugin bookkeeping, but because they are normal `WP_Query` instantiations they still fire third-party `the_posts` / `posts_results` content filters.

If an active theme or plugin hooks `the_posts` with expensive work, that work runs on **every** Cloudinary internal query. This was reported on an enterprise site whose theme injects author-archive results on `the_posts` (running `get_users()` + `count_user_posts()` per query); with Cloudinary's paginated internal queries this repeated until PHP's memory limit was exhausted and pages 500'd.

## Change

Add `'suppress_filters' => true` to the two fully-specified internal queries so they skip content filters entirely — correct behaviour for internal bookkeeping that has nothing to do with public-facing content.

## Note on WordPressVIPMinimum.SuppressFilters

The VIP standard prohibits `suppress_filters => true` because it also disables `posts_where`/`posts_join`/`posts_orderby` (used by VIP infra and multilingual plugins). These two queries are fully specified by post type / parent / status and do **not** rely on those filters, so the rule is suppressed inline with an explanatory comment. Existing precedent for VIP-restricted query usage in this codebase: `php/cache/class-cache-point.php:439`.

## Status / caveats

- Draft. The customer crash in our logs is a *different* fatal (undefined `have_rows()` from their theme during Cloudinary activation — see separate work). This PR addresses the memory-exhaustion interaction reproduced locally against the customer theme, which is **not yet confirmed** to be the issue the customer currently faces.
- Recommend holding merge until the customer confirms the temporary mu-plugin mitigation resolves their crash.

## Testing

- [ ] `init_asset_parents()` still populates asset parents correctly
- [ ] `process_parent_assets()` still iterates child assets correctly
- [ ] With a theme filtering `the_posts`, that filter no longer runs on Cloudinary internal queries
- [ ] No regression for WPML / multilingual asset queries