### PR TITLE
Bump PHPStan to level 5 and fix type/annotation issues

### DIFF
--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -153,7 +153,7 @@ class Admin {
 		$data     = array_filter(
 			$data,
 			function ( $key ) use ( $settings ) {
-				return $settings->get_setting( $key, false );
+				return (bool) $settings->get_setting( $key, false );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
@@ -210,7 +210,7 @@ class Admin {
 			$page['slug'],
 			'',
 			$page['icon'],
-			'81.5'
+			81.5
 		);
 		$connected   = $this->settings->get_param( 'connected' );
 		// Setup the Child page handles.

--- a/php/class-connect.php
+++ b/php/class-connect.php
@@ -456,7 +456,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 		$cname_str   = $this->extract_cname( $test );
 		$cname_valid = $this->validate_domain( $cname_str );
 
-		if ( $cname_str && ( ! substr_count( $cname_valid, '.' ) || false === $cname_valid ) ) {
+		if ( $cname_str && ( false === $cname_valid || ! substr_count( $cname_valid, '.' ) ) ) {
 			$result['type']    = 'invalid_cname';
 			$result['message'] = __( 'CNAME is not a valid domain name.', 'cloudinary' );
 
@@ -632,7 +632,7 @@ class Connect extends Settings_Component implements Config, Setup, Notice {
 	 *
 	 * @param string $domain The domain.
 	 *
-	 * @return bool
+	 * @return string|false
 	 */
 	protected function validate_domain( $domain ) {
 		$is_valid = false;

--- a/php/class-deactivation.php
+++ b/php/class-deactivation.php
@@ -185,7 +185,7 @@ class Deactivation {
 
 		$is_cloudinary_only = 'cld' === $this->plugin->settings->get_value( 'offload' );
 		?>
-		<div id="cloudinary-deactivation" class="cld-modal" data-cloudinary-only="<?php echo esc_attr( $is_cloudinary_only ); ?>">
+		<div id="cloudinary-deactivation" class="cld-modal" data-cloudinary-only="<?php echo esc_attr( (string) $is_cloudinary_only ); ?>">
 			<div class="cloudinary-deactivation cld-modal-box">
 				<?php if ( $is_cloudinary_only ) : ?>
 					<div class="modal-header" id="modal-header">
@@ -495,7 +495,7 @@ class Deactivation {
 
 		foreach ( $user_meta_keys as $key ) {
 			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
-			delete_metadata( 'user', null, $key, '', true );
+			delete_metadata( 'user', 0, $key, '', true );
 		}
 	}
 
@@ -528,7 +528,7 @@ class Deactivation {
 
 		foreach ( $term_meta_keys as $key ) {
 			// Inspired on https://developer.wordpress.org/reference/functions/delete_post_meta_by_key/.
-			delete_metadata( 'term', null, $key, '', true );
+			delete_metadata( 'term', 0, $key, '', true );
 		}
 	}
 

--- a/php/class-delivery.php
+++ b/php/class-delivery.php
@@ -1830,7 +1830,7 @@ class Delivery implements Setup {
 	/**
 	 * Set url usability.
 	 *
-	 * @param object    $item      The item object result.
+	 * @param array     $item      The item result.
 	 * @param null|bool $auto_sync If auto_sync is on.
 	 */
 	protected function set_usability( $item, $auto_sync = null ) {
@@ -1841,9 +1841,9 @@ class Delivery implements Setup {
 		 * @hook   cloudinary_set_usable_asset
 		 * @since  3.0.2
 		 *
-		 * @param object $item The found asset object.
+		 * @param array $item The found asset.
 		 *
-		 * @return object
+		 * @return array
 		 */
 		$item = apply_filters( 'cloudinary_set_usable_asset', $item );
 
@@ -1873,7 +1873,7 @@ class Delivery implements Setup {
 		 * @since  3.1.6
 		 *
 		 * @param string $url         The URL to be searched for and prepared to be delivered by Cloudinary.
-		 * @param object $item        The found asset object.
+		 * @param array  $item        The found asset.
 		 * @param string $content_url The content URL.
 		 *
 		 * @return string

--- a/php/class-media-library.php
+++ b/php/class-media-library.php
@@ -45,7 +45,7 @@ class Media_Library extends Extension {
 			self::MEDIA_LIBRARY_SLUG,
 			array( $this, 'render' ),
 			'dashicons-cloudinary-dam',
-			'81.6'
+			81.6
 		);
 	}
 

--- a/php/class-media.php
+++ b/php/class-media.php
@@ -1357,11 +1357,11 @@ class Media extends Settings_Component implements Setup {
 	/**
 	 * Generate a Cloudinary URL based on attachment ID and required size.
 	 *
-	 * @param int          $attachment_id             The id of the attachment.
-	 * @param array|string $size                      The wp size to set for the URL.
-	 * @param array|string $transformations           Set of transformations to apply to this url.
-	 * @param string|null  $cloudinary_id             Optional forced cloudinary ID.
-	 * @param bool         $overwrite_transformations Flag url is a breakpoint URL to stop re-applying default transformations.
+	 * @param int                    $attachment_id             The id of the attachment.
+	 * @param array|string|bool|null $size                      The wp size to set for the URL.
+	 * @param array|string|bool|null $transformations           Set of transformations to apply to this url.
+	 * @param string|null            $cloudinary_id             Optional forced cloudinary ID.
+	 * @param bool                   $overwrite_transformations Flag url is a breakpoint URL to stop re-applying default transformations.
 	 *
 	 * @return string|null The converted URL.
 	 */
@@ -2058,7 +2058,7 @@ class Media extends Settings_Component implements Setup {
 		$max_files = apply_filters( 'cloudinary_max_files_import', 20 );
 
 		// External assets.
-		wp_enqueue_script( 'cloudinary-media-modal', $this->plugin->dir_url . '/js/media-modal.js', null, $this->plugin->version, true );
+		wp_enqueue_script( 'cloudinary-media-modal', $this->plugin->dir_url . '/js/media-modal.js', array(), $this->plugin->version, true );
 		wp_enqueue_script( 'cloudinary-media-library', CLOUDINARY_ENDPOINTS_MEDIA_LIBRARY, $deps, $this->plugin->version, true );
 		wp_enqueue_script( 'cloudinary-terms-order', $this->plugin->dir_url . '/js/terms-order.js', array( 'jquery', 'wp-i18n' ), $this->plugin->version, true );
 		wp_enqueue_style( 'cloudinary' );
@@ -2638,7 +2638,7 @@ class Media extends Settings_Component implements Setup {
 					$time = "_{$time}";
 				} else { // Readable request.
 					$to_unset = "_{$time}";
-					$time     = gmdate( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $time );
+					$time     = gmdate( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $time );
 				}
 
 				// Maybe cleanup log entries.
@@ -2682,9 +2682,9 @@ class Media extends Settings_Component implements Setup {
 	/**
 	 * Update cloudinary metadata.
 	 *
-	 * @param int          $post_id The attachment ID.
-	 * @param string       $key     The meta key to get.
-	 * @param string|array $data    $the meta data to update.
+	 * @param int    $post_id The attachment ID.
+	 * @param string $key     The meta key to get.
+	 * @param mixed  $data    The meta data to update.
 	 *
 	 * @return bool
 	 */

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -194,7 +194,12 @@ final class Plugin {
 	public function setup_settings() {
 		$params         = $this->get_settings_page_structure();
 		$this->settings = new Settings( $this->slug, $params );
-		$components     = array_filter( $this->components, array( $this, 'is_setting_component' ) );
+		/**
+		 * Components implementing Settings_Component.
+		 *
+		 * @var Settings_Component[] $components
+		 */
+		$components = array_filter( $this->components, array( $this, 'is_setting_component' ) );
 		$this->init_component_settings( $components );
 
 		// Setup connection.
@@ -328,7 +333,7 @@ final class Plugin {
 	public function register_assets() {
 		// Register Main.
 		wp_register_script( 'cloudinary', $this->dir_url . 'js/cloudinary.js', array( 'jquery', 'wp-util' ), $this->version, true );
-		wp_register_style( 'cloudinary', $this->dir_url . 'css/cloudinary.css', null, $this->version );
+		wp_register_style( 'cloudinary', $this->dir_url . 'css/cloudinary.css', array(), $this->version );
 
 		$components = array_filter( $this->components, array( $this, 'is_asset_component' ) );
 		array_map(

--- a/php/class-sync.php
+++ b/php/class-sync.php
@@ -814,9 +814,9 @@ class Sync implements Setup, Assets {
 		 *
 		 * @hook   cloudinary_sync_base
 		 *
-		 * @param array $signatures   The attachments required signatures.
-		 * @param WP_Post $post The attachment post.
-		 * @param Sync $sync    The sync object instance.
+		 * @param array         $signatures The attachments required signatures.
+		 * @param \WP_Post|null $post       The attachment post.
+		 * @param Sync          $sync       The sync object instance.
 		 *
 		 * @return array
 		 */

--- a/php/connect/class-api.php
+++ b/php/connect/class-api.php
@@ -186,9 +186,9 @@ class Api {
 	/**
 	 * Return an endpoint for a specific resource type.
 	 *
-	 * @param string $resource The resource type for the endpoint.
-	 * @param string $function The function of the endpoint.
-	 * @param bool   $endpoint Flag to get an endpoint or an asset url.
+	 * @param string|null $resource The resource type for the endpoint.
+	 * @param string|null $function The function of the endpoint.
+	 * @param bool        $endpoint Flag to get an endpoint or an asset url.
 	 *
 	 * @return string
 	 */
@@ -437,7 +437,7 @@ class Api {
 
 		// Since WP_Filesystem doesn't have a fread, we need to do it manually. However we'll still use it for writing.
 		$src            = fopen( $args['file'], 'r' ); // phpcs:ignore
-		$temp_file_name = wp_tempnam( uniqid( time() ) . '.' . Utils::pathinfo( $args['file'], PATHINFO_EXTENSION ) );
+		$temp_file_name = wp_tempnam( uniqid( (string) time() ) . '.' . Utils::pathinfo( $args['file'], PATHINFO_EXTENSION ) );
 		$upload_id      = substr( sha1( uniqid( $this->credentials['api_secret'] . wp_rand() ) ), 0, 16 );
 		$chunk_size     = 20000000;
 		$index          = 0;
@@ -500,10 +500,10 @@ class Api {
 	/**
 	 * Upload an asset.
 	 *
-	 * @param int   $attachment_id Attachment ID to upload.
-	 * @param array $args          Array of upload options.
-	 * @param array $headers       Additional headers to use in upload.
-	 * @param bool  $try_remote    Flag to try_remote upload.
+	 * @param int|string $attachment_id Attachment ID to upload, or a file path for raw uploads.
+	 * @param array      $args          Array of upload options.
+	 * @param array      $headers       Additional headers to use in upload.
+	 * @param bool       $try_remote    Flag to try_remote upload.
 	 *
 	 * @return array|\WP_Error
 	 */
@@ -1026,7 +1026,7 @@ class Api {
 			return $request;
 		}
 		$body   = wp_remote_retrieve_body( $request );
-		$result = json_decode( $body, ARRAY_A );
+		$result = json_decode( $body, true );
 		if ( empty( $result ) && ! empty( $body ) ) {
 			return $body; // not json.
 		}

--- a/php/cron/class-lock-file.php
+++ b/php/cron/class-lock-file.php
@@ -27,7 +27,7 @@ class Lock_File {
 	/**
 	 * Get a lock data.
 	 *
-	 * @param string|null $file The lock name.
+	 * @param string|int|null $file The lock name.
 	 *
 	 * @return false|mixed|string
 	 */
@@ -50,7 +50,7 @@ class Lock_File {
 	/**
 	 * Get the lock name.
 	 *
-	 * @param string|null $file_name The name of the transient.
+	 * @param string|int|null $file_name The name of the transient.
 	 *
 	 * @return mixed|string|null
 	 */
@@ -66,7 +66,7 @@ class Lock_File {
 	/**
 	 * Check if a lock is in place.
 	 *
-	 * @param string|null $file The lock name.
+	 * @param string|int|null $file The lock name.
 	 *
 	 * @return bool
 	 */
@@ -87,14 +87,14 @@ class Lock_File {
 	/**
 	 * Set a lock.
 	 *
-	 * @param string|null $file The name to set.
-	 * @param mixed       $data The data to set.
+	 * @param string|int|null $file The name to set.
+	 * @param mixed           $data The data to set.
 	 *
 	 * @return mixed|string
 	 */
 	public function set_lock_file( $file = null, $data = null ) {
 		$time = time();
-		$bits = $data ? $data : uniqid( $time );
+		$bits = $data ? $data : uniqid( (string) $time );
 		if ( ! $this->has_lock_file( $file ) ) {
 			$file_path = $this->get_lock_file_name( $file );
 			file_put_contents( $file_path, $bits ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
@@ -106,7 +106,7 @@ class Lock_File {
 	/**
 	 * Delete a lock.
 	 *
-	 * @param string|null $file The name to set.
+	 * @param string|int|null $file The name to set.
 	 */
 	public function delete_lock_file( $file = null ) {
 		$file = $this->get_lock_file_name( $file );

--- a/php/cron/class-lock-object.php
+++ b/php/cron/class-lock-object.php
@@ -67,7 +67,7 @@ class Lock_Object extends Lock_File {
 	 */
 	public function set_lock_file( $file = null, $data = null ) {
 		$time = time();
-		$bits = $data ? json_decode( $data, true ) : uniqid( $time );
+		$bits = $data ? json_decode( $data, true ) : uniqid( (string) $time );
 		if ( ! $this->has_lock_file( $file ) ) {
 			set_transient( self::PREFIX . $this->get_lock_file_name( $file ), $bits, Cron::$daemon_watcher_interval );
 		}

--- a/php/delivery/class-lazy-load.php
+++ b/php/delivery/class-lazy-load.php
@@ -169,7 +169,7 @@ class Lazy_Load extends Delivery_Feature {
 			'data-image' => wp_json_encode( $options ),
 		);
 
-		return HTML::build_tag( 'noscript', $atts ) . $tag . HTML::build_tag( 'noscript', null, 'close' );
+		return HTML::build_tag( 'noscript', $atts ) . $tag . HTML::build_tag( 'noscript', array(), 'close' );
 	}
 
 	/**
@@ -349,7 +349,7 @@ class Lazy_Load extends Delivery_Feature {
 	 * Register front end hooks.
 	 */
 	public function register_assets() {
-		wp_register_script( 'cld-lazy-load', $this->plugin->dir_url . 'js/lazy-load.js', null, $this->plugin->version, false );
+		wp_register_script( 'cld-lazy-load', $this->plugin->dir_url . 'js/lazy-load.js', array(), $this->plugin->version, false );
 	}
 
 	/**

--- a/php/integrations/class-wpml.php
+++ b/php/integrations/class-wpml.php
@@ -248,7 +248,7 @@ class WPML extends Integrations {
 				break;
 			}
 
-			$relationship            = new Relationship( $args['asset'] );
+			$relationship            = new Relationship( (int) $args['asset'] );
 			$contextual_relationship = $relationship->get_contextualized_relationship( $language );
 
 			if ( ! empty( $contextual_relationship ) ) {

--- a/php/media/class-filter.php
+++ b/php/media/class-filter.php
@@ -537,7 +537,7 @@ class Filter {
 		$shortcodes = $this->get_video_shortcodes( $html );
 		foreach ( $shortcodes as $shortcode ) {
 			// Add ID.
-			$new_atts = $shortcode['args'] . ' id="' . esc_attr( $id ) . '"';
+			$new_atts = $shortcode['args'] . ' id="' . esc_attr( (string) $id ) . '"';
 
 			// Add defaults.
 			$settings = $this->media->get_settings()->get_value( 'video_settings' );

--- a/php/media/class-global-transformations.php
+++ b/php/media/class-global-transformations.php
@@ -235,7 +235,7 @@ class Global_Transformations {
 				switch ( $screen->base ) {
 					case 'term':
 						$term_id         = filter_input( INPUT_GET, 'tag_ID', FILTER_SANITIZE_NUMBER_INT );
-						$transformations = $this->get_term_transformations( $term_id, $type );
+						$transformations = $this->get_term_transformations( (int) $term_id, $type );
 						break;
 					default:
 						$transformations = array();
@@ -428,7 +428,7 @@ class Global_Transformations {
 	 */
 	public function make_term_sort_item( $id, $name ) {
 		$out = array(
-			'<li class="cld-tax-order-list-item" data-item="' . esc_attr( $id ) . '">',
+			'<li class="cld-tax-order-list-item" data-item="' . esc_attr( (string) $id ) . '">',
 			'<span class="dashicons dashicons-menu cld-tax-order-list-item-handle"></span>',
 			'<input class="cld-tax-order-list-item-input" type="hidden" name="cld_tax_order[]" value="' . $id . '">' . $name,
 			'</li>',

--- a/php/media/class-upgrade.php
+++ b/php/media/class-upgrade.php
@@ -141,7 +141,7 @@ class Upgrade {
 			// Check folder sync in order and if it's not a URL.
 			if ( ! wp_http_validate_url( $file ) && $this->media->is_folder_synced( $attachment_id ) ) {
 				$public_id_folder = ltrim( dirname( $this->media->get_public_id( $attachment_id ) ) );
-				$test_signature   = md5( false );
+				$test_signature   = md5( (string) false );
 				$folder_signature = md5( $public_id_folder );
 				$signature        = $this->sync->get_signature( $attachment_id );
 				if ( $folder_signature !== $test_signature && $test_signature === $signature['folder'] ) {

--- a/php/media/class-video.php
+++ b/php/media/class-video.php
@@ -178,8 +178,8 @@ class Video {
 			$player_style_url  = sprintf( CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_STYLE, CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION );
 			$player_script_url = sprintf( CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_SCRIPT, CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION );
 
-			wp_register_style( 'cld-player', $player_style_url, null, CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION );
-			wp_register_script( 'cld-core', $core_url, null, CLOUDINARY_ENDPOINTS_CORE_VERSION, true );
+			wp_register_style( 'cld-player', $player_style_url, array(), CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION );
+			wp_register_script( 'cld-core', $core_url, array(), CLOUDINARY_ENDPOINTS_CORE_VERSION, true );
 			wp_register_script( 'cld-player', $player_script_url, array( 'cld-core' ), CLOUDINARY_ENDPOINTS_VIDEO_PLAYER_VERSION, true );
 		}
 	}

--- a/php/sync/class-sync-queue.php
+++ b/php/sync/class-sync-queue.php
@@ -778,8 +778,8 @@ class Sync_Queue {
 	/**
 	 * Add to a threads queue.
 	 *
-	 * @param int   $thread         Thread ID.
-	 * @param array $attachment_ids The ID to add.
+	 * @param string $thread         Thread name.
+	 * @param array  $attachment_ids The ID to add.
 	 */
 	public function add_to_thread_queue( $thread, array $attachment_ids ) {
 
@@ -856,7 +856,7 @@ class Sync_Queue {
 
 		$attachment_ids = $been_synced;
 		if ( ! empty( $attachment_ids ) ) {
-			$chunk_size = ceil( count( $attachment_ids ) / count( $threads ) );
+			$chunk_size = (int) ceil( count( $attachment_ids ) / count( $threads ) );
 			$chunks     = array_chunk( $attachment_ids, $chunk_size );
 			foreach ( $chunks as $index => $chunk ) {
 				$thread = array_shift( $threads );

--- a/php/traits/trait-cli.php
+++ b/php/traits/trait-cli.php
@@ -416,8 +416,8 @@ trait CLI_Trait {
 			$diff          = $name_length - $max_length;
 			$concat_length = $diff > 3 ? 3 : $diff;
 			$usable_length = $max_length - $concat_length;
-			$front         = substr( $name, 0, floor( $usable_length / 2 ) );
-			$back          = substr( $name, strlen( $name ) - ceil( $usable_length / 2 ) );
+			$front         = substr( $name, 0, (int) floor( $usable_length / 2 ) );
+			$back          = substr( $name, strlen( $name ) - (int) ceil( $usable_length / 2 ) );
 			$name          = $front . implode( array_fill( 0, $concat_length, $concat_char ) ) . $back;
 		}
 		$used_length = $max_length - strlen( $name );

--- a/php/ui/class-component.php
+++ b/php/ui/class-component.php
@@ -618,7 +618,7 @@ abstract class Component {
 	/**
 	 * Get a build part to construct.
 	 *
-	 * @param string $part The part name.
+	 * @param string|null $part The part name.
 	 *
 	 * @return array
 	 */

--- a/php/ui/component/class-asset-preview.php
+++ b/php/ui/component/class-asset-preview.php
@@ -31,7 +31,7 @@ class Asset_Preview extends Asset {
 	 * @return array
 	 */
 	protected function preview( $struct ) {
-		$attachment = filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
+		$attachment = (int) filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
 		$dataset    = $this->assets->get_asset( $attachment, 'dataset' );
 
 		// Check if the attachment is a video.
@@ -63,7 +63,7 @@ class Asset_Preview extends Asset {
 	 * Setup the JS data before rendering.
 	 */
 	protected function pre_render() {
-		$attachment = filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
+		$attachment = (int) filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
 
 		// Check if the attachment is a video.
 		if ( $attachment && wp_attachment_is( 'video', $attachment ) ) {
@@ -104,7 +104,7 @@ class Asset_Preview extends Asset {
 		wp_enqueue_media();
 
 		// Check if the attachment is a video and enqueue video player assets.
-		$attachment = filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
+		$attachment = (int) filter_input( INPUT_GET, 'asset', FILTER_SANITIZE_NUMBER_INT );
 		if ( $attachment && wp_attachment_is( 'video', $attachment ) ) {
 			wp_enqueue_style( 'cld-player' );
 			wp_enqueue_script( 'cld-player' );

--- a/php/ui/component/class-plan-details.php
+++ b/php/ui/component/class-plan-details.php
@@ -109,7 +109,7 @@ class Plan_Details extends Component {
 		$remaining  = $units - $units_used;
 
 
-		$usage                                 = number_format_i18n( $units ) . ' per month / ' . number_format_i18n( $units_used, 2 ) . ' used';
+		$usage                                 = number_format_i18n( (float) $units ) . ' per month / ' . number_format_i18n( (float) $units_used, 2 ) . ' used';
 		$struct['children']['units']           = $this->make_item( __( 'Plan Units', 'cloudinary' ), $usage, $this->dir_url . 'css/images/units.svg' );
 		$struct['children']['remaining_units'] = $this->make_item( __( 'Remaining Units', 'cloudinary' ), number_format_i18n( $remaining, 2 ), $this->dir_url . 'css/images/units-plus.svg' );
 

--- a/php/ui/component/class-plan-status.php
+++ b/php/ui/component/class-plan-status.php
@@ -136,7 +136,7 @@ class Plan_Status extends Component {
 		$limit['attributes']['class'] = array(
 			'limit',
 		);
-		$limit['content']             = number_format_i18n( $this->connection->get_usage_stat( 'transformations', 'limit' ) );
+		$limit['content']             = number_format_i18n( (float) $this->connection->get_usage_stat( 'transformations', 'limit' ) );
 
 		$usage                        = $this->get_part( 'span' );
 		$usage['attributes']['class'] = array(

--- a/php/ui/component/class-plan.php
+++ b/php/ui/component/class-plan.php
@@ -146,7 +146,7 @@ class Plan extends Component {
 		$limit       = $this->connection->get_usage_stat( 'credits', 'limit' );
 		if ( $limit ) {
 			// translators: The number of monthly credits.
-			$description = sprintf( _n( '%d Monthly Credit', '%d Monthly Credits', $limit, 'cloudinary' ), $limit );
+			$description = sprintf( _n( '%d Monthly Credit', '%d Monthly Credits', (int) $limit, 'cloudinary' ), (int) $limit );
 		}
 
 		return $description;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,7 +14,7 @@ parameters:
 		-
 			identifier: return.void
 			message: '#^Action callback returns .+ but should not return anything\.$#'
-	level: 4
+	level: 5
 	paths:
 		- php
 		- cloudinary.php


### PR DESCRIPTION
## Approach

- Bump PHPStan analysis to level 5 in `phpstan.neon.dist`.
- Fix all 61 resulting `argument.type` errors, which were all type mismatches at call sites:
  - **Type casts at call sites** for `uniqid`, `esc_attr`, `gmdate`, `md5`, `substr`, `array_chunk`, `number_format_i18n`, `_n`, `filter_input` results, and `new Relationship`.
  - **Replaced `null`/`false` with `array()`** for `wp_register_script`/`wp_register_style`/`wp_enqueue_script` `$deps` and `Component::build_tag` `$attributes`.
  - **`delete_metadata`** `null` object id changed to `0` (the WP delete-all pattern).
  - **Widened docblocks** where methods legitimately accept broader types: `Media::cloudinary_url` (`$size`/`$transformations`), `Media::update_post_meta` (`$data` → `mixed`), `Api::upload`/`Api::url`, `Lock_File` `$file` params, `Component::get_part`, and `Sync_Queue::add_to_thread_queue`.
  - **Corrected wrong docblocks**: `Connect::validate_domain` return type (`bool` → `string|false`), `Delivery::set_usability` filter docblocks (`object` → `array`), and `Sync` filter (`WP_Post` → `\WP_Post|null`).
  - **Closure/local annotations**: `Admin::rest_save_settings` filter closure now returns `bool`; added local `@var Settings_Component[]` in `Plugin::setup_settings`.
- No runtime behavior changes; all fixes are type coercions or annotation corrections.

## QA notes

- Run `vendor/bin/phpstan analyse --memory-limit=2G` — should report **No errors** at level 5.
- Run PHP lint (`composer lint`) on the changed files — should pass with no PHPCS violations.
- Smoke test core flows (media upload/sync, delivery, admin settings, plan/usage UI) to confirm no regressions from the casts.