### PR TITLE
Fix JSON shape corruption in REST API responses breaking MCP integrations (Novamira)

### DIFF
--- a/php/class-string-replace.php
+++ b/php/class-string-replace.php
@@ -298,10 +298,13 @@ class String_Replace implements Setup {
 		if ( ! empty( $this->context ) ) {
 			$context = $this->context;
 		}
+		$is_json = false;
 		if ( Utils::looks_like_json( $content ) ) {
-			$json_maybe = json_decode( $content, true );
-			if ( ! empty( $json_maybe ) ) {
+			// Decode as objects, not associative arrays, so JSON object/array shape (e.g. empty objects `{}`) survives the round trip below.
+			$json_maybe = json_decode( $content );
+			if ( null !== $json_maybe ) {
 				$content = $json_maybe;
+				$is_json = true;
 			}
 		}
 		$this->prime_replacements( $content, $context );
@@ -309,7 +312,7 @@ class String_Replace implements Setup {
 			$content = self::do_replace( $content );
 		}
 		self::reset();
-		$last_content = ! empty( $json_maybe ) ? wp_json_encode( $content ) : $content;
+		$last_content = $is_json ? wp_json_encode( $content ) : $content;
 
 		return $last_content;
 	}


### PR DESCRIPTION
## Summary

A customer reported that activating the Cloudinary plugin breaks MCP communication between Claude and WordPress when using the Novamira MCP plugin, requiring a reconnect that then fails.

**Root cause:** `String_Replace::replace_strings()` buffers and rewrites *every* REST API response site-wide (not just Cloudinary's own routes) to swap local media URLs for Cloudinary URLs. To do this on JSON output it ran `json_decode( $content, true )` (associative-array mode) and, after replacing, re-serialized with `wp_json_encode()`. PHP's associative decoding collapses empty JSON objects (`{}`) into plain arrays, which are indistinguishable from empty JSON arrays — so the re-encode silently turned any `{}` in a REST response into `[]`, even when there was nothing for Cloudinary to actually replace.

MCP servers (Novamira's included) return JSON-RPC payloads that routinely contain empty objects — e.g. a zero-parameter tool's `inputSchema.properties: {}`. MCP clients validate these responses against a strict schema, so `{}` silently becoming `[]` fails validation and the client drops the connection. This isn't Novamira-specific — it corrupts the shape of any REST JSON response containing an empty object once Cloudinary is connected.

**Fix:** decode as objects instead of associative arrays (`json_decode( $content )` without `true`), and gate the re-encode on an explicit "did decoding succeed" check rather than PHP truthiness. Objects round-trip as objects and arrays as arrays, so shape is preserved. This is a one-file, minimal change — it doesn't alter which routes get buffered/filtered, only fixes the encoding fidelity bug.

## Reproduction

Confirmed end-to-end against a real Cloudinary connection + the real Novamira MCP plugin:

1. Connect Novamira to Claude, verify it works.
2. Install/activate Cloudinary, complete a real connection (Connect → verified `cloudinary_status: ok`).
3. Call the live MCP endpoint (`tools/list`) — on unpatched code, `mcp-adapter-discover-abilities`'s `inputSchema` comes back as `{"type":"object","properties":[]}` instead of `{"type":"object","properties":{}}`.
4. With this fix applied, the same call returns `{"type":"object","properties":{}}` — correct shape, everything else identical.

Note: the buggy code path only activates once `Connect::is_connected()` passes (i.e. Cloudinary is actually connected to an account, not just "active") — matching the customer's report that "a working Cloudinary configuration was already in place."

## QA steps

1. Install and activate the Novamira MCP plugin (or any plugin/client that consumes `wp-json` and validates JSON strictly — e.g. any JSON-RPC/MCP integration).
2. Connect it to an AI client (or otherwise confirm its REST endpoint returns well-formed responses) — verify it works *before* Cloudinary is involved.
3. Install and activate the Cloudinary plugin, and complete a real Cloudinary connection (Connect page, valid credentials).
4. Reconnect / re-verify the Novamira (or other) integration — it should now succeed where it previously failed.
5. Directly inspect a REST response containing an empty object (e.g. Novamira's `tools/list`, or any endpoint whose JSON has a field like `{}`) and confirm it stays `{}` rather than becoming `[]`.
6. Regression-check Cloudinary's own core feature isn't affected: edit a post with images in the block editor (Gutenberg REST save/load) and confirm media URLs are still correctly rewritten to Cloudinary URLs, and that the front-end/admin media replacement behavior is unchanged.