### PR TITLE
Add Dependabot config for Composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     schedule:
       interval: weekly
     target-branch: develop
+    groups:
+      wordpress:
+        patterns:
+          - "@wordpress/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: develop
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: develop


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` enabling Dependabot for the Composer and npm ecosystem
- Weekly update schedule
- PRs are targeted to the `develop` branch only