### PR TITLE
Gh Docs: Restrict action trigger to only prod releases

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,11 +1,8 @@
 name: Build Docs
 
 on:
-  push:
-    branches:
-      - master
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Approach

- Adjust GH action to only trigger when publishing a new release
- Remove trigger on push to `master`
- Change release types from `published` to `released` so that `pre-released` aren't triggering it

## QA notes

- Ensure the action doesn't trigger on push to master anymore
- Ensure it still triggers when creating a new prod release