### PR TITLE
Upgrade local env & CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache Composer
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Cache Composer
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.4', '8.3' ]
+        php-version: [ '7.4', '8.5' ]
 
     steps:
       - name: Checkout repository
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
 
       - name: Cache Composer
         uses: actions/cache@v4

--- a/.github/workflows/deploy-to-wp-org.yml
+++ b/.github/workflows/deploy-to-wp-org.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           tools: composer:v2
 
       - name: Get Composer cache directory

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
-  "core": "WordPress/WordPress#7.0",
-  "phpVersion": "8.2",
+  "core": "WordPress/WordPress#7.1",
+  "phpVersion": "8.5",
   "plugins": ["."],
   "config": {
     "WP_DEBUG": true,

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Stay tuned for updates, tips and tutorials: [Blog](https://cloudinary.com/blog),
 
 ### Prerequisites
 
--   [Node.js](https://nodejs.org/) v16+ (see `.nvmrc`)
--   [npm](https://www.npmjs.com/) v6.9+
+-   [Node.js](https://nodejs.org/) v22+ (see `.nvmrc`)
+-   [npm](https://www.npmjs.com/) v10+
 -   [Composer](https://getcomposer.org/)
 -   [Docker](https://www.docker.com/) (required for the WordPress local environment via `wp-env`)
 


### PR DESCRIPTION
## Approach

- Upgrade WP core to 7.1 and PHP to 8.5 on wp-env
- Upgrade PHP version in CI as well
- Reference `.nvmrc` file for Node version in CI instead of hard coding the node version

## QA notes

- Make sure the local environment still run as expected when starting it `npm run env:start`
- Make sure CI jobs are still passing
