### PR TITLE
Analytics: reliable activation event, stable install identity, consistent categories

### DIFF
--- a/php/class-admin.php
+++ b/php/class-admin.php
@@ -538,9 +538,10 @@ class Admin {
 
 		$analytics->track(
 			'transformation_applied',
-			'media',
+			'feature_usage',
 			null,
 			array(
+				'feature'              => 'transformation',
 				'scope'                => 'global',
 				'transformation_count' => count( $matched ),
 			)
@@ -565,9 +566,10 @@ class Admin {
 
 		$analytics->track(
 			'gallery_configured',
-			'features',
+			'feature_usage',
 			null,
 			array(
+				'feature'     => 'gallery',
 				'layout'      => isset( $config['displayProps']['mode'] ) ? $config['displayProps']['mode'] : '',
 				'media_count' => isset( $config['mediaAssets'] ) && is_array( $config['mediaAssets'] ) ? count( $config['mediaAssets'] ) : 0,
 			)

--- a/php/class-analytics.php
+++ b/php/class-analytics.php
@@ -121,7 +121,7 @@ class Analytics {
 					'new_version'            => $current,
 					'days_since_last_active' => $days_since_last_active,
 				),
-				HOUR_IN_SECONDS
+				DAY_IN_SECONDS
 			);
 		} catch ( \Throwable $e ) {
 			// Fail silent: activation must never break.
@@ -147,6 +147,11 @@ class Analytics {
 	 * @return void
 	 */
 	public function maybe_send_pending_activation() {
+		// Leave the stash intact if emission is disabled, so the event is not
+		// consumed-and-dropped and can still be sent on a later admin load.
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
 		$pending = get_transient( self::PENDING_ACTIVATION );
 		if ( empty( $pending ) || ! is_array( $pending ) ) {
 			return;
@@ -314,6 +319,7 @@ class Analytics {
 			'wp_version'     => get_bloginfo( 'version' ),
 			'php_version'    => PHP_VERSION,
 			'site_id'        => hash( 'sha256', home_url() ),
+			'install_id'     => $this->get_install_id(),
 			'session_id'     => $this->get_session_id(),
 			'user_role'      => $this->get_user_role(),
 			'is_multisite'   => is_multisite(),
@@ -333,6 +339,25 @@ class Analytics {
 		}
 
 		return $params;
+	}
+
+	/**
+	 * Stable, session-independent installation identifier.
+	 *
+	 * Generated once and persisted, so events emitted off-interactive
+	 * (cron/queue/front-end), where `session_id` is empty, still carry a
+	 * durable join key. Unlike `site_id` it survives a domain change.
+	 *
+	 * @return string
+	 */
+	protected function get_install_id() {
+		$id = get_option( '_cloudinary_install_id' );
+		if ( empty( $id ) ) {
+			$id = wp_generate_uuid4();
+			add_option( '_cloudinary_install_id', $id, '', false );
+		}
+
+		return (string) $id;
 	}
 
 	/**
@@ -369,7 +394,13 @@ class Analytics {
 			return (string) reset( $user->roles );
 		}
 
-		return '';
+		// No acting user (cron/queue/front-end): record the context instead of
+		// an empty string so off-interactive events remain distinguishable.
+		if ( wp_doing_cron() ) {
+			return 'cron';
+		}
+
+		return is_admin() ? 'system' : 'front';
 	}
 
 	/**
@@ -475,7 +506,7 @@ class Analytics {
 		}
 		set_transient( $throttle_key, true, 5 * MINUTE_IN_SECONDS );
 
-		$this->track( 'poc_smoke_test', 'poc' );
+		$this->track( 'poc_smoke_test', 'system' );
 	}
 
 	/**

--- a/php/class-assets.php
+++ b/php/class-assets.php
@@ -193,9 +193,10 @@ class Assets extends Settings_Component {
 
 		$analytics->track(
 			'cache_uploaded',
-			'cache',
+			'feature_usage',
 			null,
 			array(
+				'feature'    => 'asset_sync',
 				'item_count' => 1,
 				'status'     => is_wp_error( $result ) ? 'error' : 'success',
 			)

--- a/php/class-deactivation.php
+++ b/php/class-deactivation.php
@@ -446,7 +446,7 @@ class Deactivation {
 		if ( $analytics && ! $is_contact_flow ) {
 			$analytics->track(
 				'deactivation_submitted',
-				'deactivation',
+				'activation_funnel',
 				null,
 				array(
 					'reason_id'     => sanitize_text_field( $reason ),


### PR DESCRIPTION
## What & why

Four correctness/consistency fixes to the plugin analytics instrumentation (built on the activation-funnel work already on `develop`).

### The fixes

1. **Activation event no longer dropped when emission is disabled.** `maybe_send_pending_activation()` now bails on `! is_enabled()` **before** consuming the pending transient, so the event isn't consumed-and-dropped — it can still be sent on a later admin load. Stash TTL widened `HOUR_IN_SECONDS` → `DAY_IN_SECONDS`.

2. **Stable `install_id`.** A persistent UUID (`_cloudinary_install_id`, non-autoloaded) is added to every event envelope in `base_params()` via the new `get_install_id()` helper. This gives off-interactive events (cron / queue / front-end, where `session_id` is empty) a durable join key. Unlike `site_id`, it survives a domain change.

3. **`user_role` context marker.** Returns `cron` / `system` / `front` instead of `''` when there is no acting user, so off-interactive events stay distinguishable.

4. **Normalized `event_category`** to a fixed set — `activation_funnel | feature_usage | settings | system` — moving specifics to a `feature` property:
   - `transformation_applied` → `feature_usage` + `feature: transformation`
   - `gallery_configured` → `feature_usage` + `feature: gallery`
   - `cache_uploaded` → `feature_usage` + `feature: asset_sync`
   - `deactivation_submitted` → `activation_funnel`
   - `poc_smoke_test` → `system`

## ⚠️ Collector / dashboard impact

Fix #4 changes `event_category` values **on the wire**. The downstream collector/dashboard schema must be coordinated with these normalized categories and the new `feature` property. (This aligns with the analytics dashboard spec.)

## Testing

- Husky / lint-staged PHPCS (WordPress-VIP ruleset) passes on commit.

## Follow-ups (tracked separately, not in this PR)

- Asset-sync adoption + extent (`asset_sync_configured` on assets-page save; `source`/`is_external` on `cache_uploaded`) — needs Settings-API keys verified against a running install.
- Weekly usage-heartbeat WP-Cron event for retention + silent-churn detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
